### PR TITLE
Added COPYRIGHT.md and refer to that file in license headers

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,2 @@
+Copyright (c) 2019, Laminas Foundation.
+All rights reserved. (https://getlaminas.org/)

--- a/src/autoload-functions-containerconfigtest.php
+++ b/src/autoload-functions-containerconfigtest.php
@@ -3,7 +3,7 @@
  * Provide aliases for zend-containerconfigtest functions.
  *
  * @see       https://github.com/laminas/laminas-zendframework-bridge for the canonical source repository
- * @copyright Copyright (c) 2019 Laminas Foundation (https://getlaminas.org)
+ * @copyright https://github.com/laminas/laminas-zendframework-bridge/blob/master/COPYRIGHT.md
  * @license   https://github.com/laminas/laminas-zendframework-bridge/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/autoload-functions-diactoros.php
+++ b/src/autoload-functions-diactoros.php
@@ -3,7 +3,7 @@
  * Provide aliases for zend-diactoros functions.
  *
  * @see       https://github.com/laminas/laminas-zendframework-bridge for the canonical source repository
- * @copyright Copyright (c) 2019 Laminas Foundation (https://getlaminas.org)
+ * @copyright https://github.com/laminas/laminas-zendframework-bridge/blob/master/COPYRIGHT.md
  * @license   https://github.com/laminas/laminas-zendframework-bridge/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/autoload-functions-stratigility.php
+++ b/src/autoload-functions-stratigility.php
@@ -3,7 +3,7 @@
  * Provide aliases for zend-stratigilty functions.
  *
  * @see       https://github.com/laminas/laminas-zendframework-bridge for the canonical source repository
- * @copyright Copyright (c) 2019 Laminas Foundation (https://getlaminas.org)
+ * @copyright https://github.com/laminas/laminas-zendframework-bridge/blob/master/COPYRIGHT.md
  * @license   https://github.com/laminas/laminas-zendframework-bridge/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/laminas/laminas-zendframework-bridge for the canonical source repository
- * @copyright Copyright (c) 2019 Laminas Foundation (https://getlaminas.org)
+ * @copyright https://github.com/laminas/laminas-zendframework-bridge/blob/master/COPYRIGHT.md
  * @license   https://github.com/laminas/laminas-zendframework-bridge/blob/master/LICENSE.md New BSD License
  */
 


### PR DESCRIPTION
As we discussed previously, to avoid adding copyright year in every file, we can add `COPYRIGHT.md` and refer to that file in license headers.