### PR TITLE
fix: better detection of Stratigility functions

### DIFF
--- a/src/autoload-functions-stratigility-v2.php
+++ b/src/autoload-functions-stratigility-v2.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Provide aliases for zend-stratigilty v2 functions.
+ *
+ * @see       https://github.com/laminas/laminas-zendframework-bridge for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-zendframework-bridge/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-zendframework-bridge/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility;
+
+use Laminas\Stratigility\Middleware\CallableMiddlewareDecorator;
+use Laminas\Stratigility\Middleware\DoublePassMiddlewareDecorator;
+use Laminas\Stratigility\Middleware\PathMiddlewareDecorator;
+use Psr\Http\Message\ResponseInterface;
+use Webimpress\HttpMiddlewareCompatibility;
+
+use function Laminas\Stratigility\doublePassMiddleware as laminasDoublePassMiddleware;
+use function Laminas\Stratigility\middleware as laminasMiddleware;
+use function Laminas\Stratigility\path as laminasPath;
+
+/**
+ * @return DoublePassMiddlewareDecorator
+ */
+function doublePassMiddleware(callable $middleware, ResponseInterface $response = null)
+{
+    return laminasDoublePassMiddleware($middleware, $response);
+}
+
+/**
+ * @return CallableMiddlewareDecorator
+ */
+function middleware(callable $middleware)
+{
+    return laminasMiddleware($middleware);
+}
+
+/**
+ * @param string $path
+ * @return PathMiddlewareDecorator
+ */
+function path(
+    $path,
+    HttpMiddlewareCompatibility\MiddlewareInterface $middleware
+) {
+    return laminasPath($path, $middleware);
+}

--- a/src/autoload-functions-stratigility-v3.php
+++ b/src/autoload-functions-stratigility-v3.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Provide aliases for zend-stratigilty v3 functions.
+ *
+ * @see       https://github.com/laminas/laminas-zendframework-bridge for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-zendframework-bridge/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-zendframework-bridge/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Stratigility;
+
+use Laminas\Stratigility\Middleware\CallableMiddlewareDecorator;
+use Laminas\Stratigility\Middleware\DoublePassMiddlewareDecorator;
+use Laminas\Stratigility\Middleware\HostMiddlewareDecorator;
+use Laminas\Stratigility\Middleware\PathMiddlewareDecorator;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\MiddlewareInterface;
+
+use function Laminas\Stratigility\doublePassMiddleware as laminasDoublePassMiddleware;
+use function Laminas\Stratigility\host as laminasHost;
+use function Laminas\Stratigility\middleware as laminasMiddleware;
+use function Laminas\Stratigility\path as laminasPath;
+
+function doublePassMiddleware(
+    callable $middleware,
+    ResponseInterface $response = null
+) : DoublePassMiddlewareDecorator {
+    return laminasDoublePassMiddleware($middleware, $response);
+}
+
+function host(string $host, MiddlewareInterface $middleware) : HostMiddlewareDecorator
+{
+    return laminasHost($host, $middleware);
+}
+
+function middleware(callable $middleware) : CallableMiddlewareDecorator
+{
+    return laminasMiddleware($middleware);
+}
+
+function path(string $path, MiddlewareInterface $middleware) : PathMiddlewareDecorator
+{
+    return laminasPath($path, $middleware);
+}

--- a/src/autoload-functions-stratigility.php
+++ b/src/autoload-functions-stratigility.php
@@ -10,38 +10,15 @@
 namespace Zend\Stratigility;
 
 use Laminas\Stratigility\Middleware\CallableMiddlewareDecorator;
-use Laminas\Stratigility\Middleware\DoublePassMiddlewareDecorator;
-use Laminas\Stratigility\Middleware\HostMiddlewareDecorator;
-use Laminas\Stratigility\Middleware\PathMiddlewareDecorator;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\MiddlewareInterface;
-
-use function Laminas\Stratigility\doublePassMiddleware as laminasDoublePassMiddleware;
-use function Laminas\Stratigility\host as laminasHost;
-use function Laminas\Stratigility\middleware as laminasMiddleware;
-use function Laminas\Stratigility\path as laminasPath;
+use Webimpress\HttpMiddlewareCompatibility;
 
 // Only define functions if one or more known functions do not exist
-if (! function_exists(__NAMESPACE__ . '\middleware')) {
-    function doublePassMiddleware(
-        callable $middleware,
-        ResponseInterface $response = null
-    ) : DoublePassMiddlewareDecorator {
-        return laminasDoublePassMiddleware($middleware, $response);
-    }
-
-    function host(string $host, MiddlewareInterface $middleware) : HostMiddlewareDecorator
-    {
-        return laminasHost($host, $middleware);
-    }
-
-    function middleware(callable $middleware) : CallableMiddlewareDecorator
-    {
-        return laminasMiddleware($middleware);
-    }
-
-    function path(string $path, MiddlewareInterface $middleware) : PathMiddlewareDecorator
-    {
-        return laminasPath($path, $middleware);
+// and a known class is present.
+if (! function_exists(__NAMESPACE__ . '\middleware') && class_exists(CallableMiddlewareDecorator::class)) {
+    if (interface_exists(MiddlewareInterface::class)) {
+        require __DIR__ . '/autoload-functions-stratigility-v3.php';
+    } elseif (interface_exists(HttpMiddlewareCompatibility\MiddlewareInterface::class)) {
+        require __DIR__ . '/autoload-functions-stratigility-v2.php';
     }
 }

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -8,6 +8,9 @@
 if (PHP_VERSION_ID >= 71000) {
     require __DIR__ . '/autoload-functions-containerconfigtest.php';
     require __DIR__ . '/autoload-functions-diactoros.php';
+}
+
+if (PHP_VERSION_ID >= 56000) {
     require __DIR__ . '/autoload-functions-stratigility.php';
 }
 


### PR DESCRIPTION
The functions only exist when we have a `CallableMiddlewareDecorator` class, so this patch now tests for that class being present before attempting to define the functions.

Additionally, it checks to see if the PSR-15 middleware compatibility shim interface is present. If so, it defines only the middleware, doublePass, and path functions, and does so using the appropriate typehints. If the PSR-15 interfaces are present, it will instead define the functions defined in Stratigility 3.0.

Fixes #2 