### PR TITLE
Added support for expressive integration zend packages

### DIFF
--- a/src/RewriteRules.php
+++ b/src/RewriteRules.php
@@ -17,10 +17,11 @@ class RewriteRules
         // @todo Need to determine the final name and namespace for zf-console
         return array(
             // Expressive
-            'Zend\\ProblemDetails\\'                 => 'Expressive\\',
-            'Zend\\Expressive\\Router\\ZendRouter\\' => 'Expressive\\Router\\LaminasRouter\\',
-            'Zend\\Expressive\\ZendView\\'           => 'Expressive\\LaminasView\\',
-            'Zend\\Expressive\\'                     => 'Expressive\\',
+            'Zend\\ProblemDetails\\'                                 => 'Expressive\\',
+            'Zend\\Expressive\\Authentication\\ZendAuthentication\\' => 'Expressive\\Authentication\\LaminasAuthentication\\',
+            'Zend\\Expressive\\Router\\ZendRouter\\'                 => 'Expressive\\Router\\LaminasRouter\\',
+            'Zend\\Expressive\\ZendView\\'                           => 'Expressive\\LaminasView\\',
+            'Zend\\Expressive\\'                                     => 'Expressive\\',
             // Laminas
             'Zend\\'                    => 'Laminas\\',
             'ZF\\ComposerAutoloading\\' => 'Laminas\\ComposerAutoloading\\',

--- a/src/RewriteRules.php
+++ b/src/RewriteRules.php
@@ -17,8 +17,10 @@ class RewriteRules
         // @todo Need to determine the final name and namespace for zf-console
         return array(
             // Expressive
-            'Zend\\ProblemDetails\\' => 'Expressive\\',
-            'Zend\\Expressive\\'     => 'Expressive\\',
+            'Zend\\ProblemDetails\\'                 => 'Expressive\\',
+            'Zend\\Expressive\\Router\\ZendRouter\\' => 'Expressive\\Router\\LaminasRouter\\',
+            'Zend\\Expressive\\ZendView\\'           => 'Expressive\\LaminasView\\',
+            'Zend\\Expressive\\'                     => 'Expressive\\',
             // Laminas
             'Zend\\'                    => 'Laminas\\',
             'ZF\\ComposerAutoloading\\' => 'Laminas\\ComposerAutoloading\\',


### PR DESCRIPTION
Packages:
  - `zend-expressive-authentication-zendauthentication`
  - `zend-expressive-zendrouter`
  - `zend-expressive-zendviewrenderer`

provides integration expressive with other zf packages. We need to rename these repositories so the namespace should be rewritten using different rules.

This PR provides new namespaces.

**To think...**
Maybe we should consider changing the following to keep consistent package name and namespace::
  - use `Expressive\LaminasRouter` namespace instead of `Expressive\Router\LaminasRouter`
  - use `expressive-laminasview` package name instead of `expressive-laminasviewrenderer`


