### PR TITLE
Fixed rewrite rules for expressive router adapters

### DIFF
--- a/src/RewriteRules.php
+++ b/src/RewriteRules.php
@@ -19,7 +19,9 @@ class RewriteRules
             // Expressive
             'Zend\\ProblemDetails\\'                                 => 'Expressive\\ProblemDetails\\',
             'Zend\\Expressive\\Authentication\\ZendAuthentication\\' => 'Expressive\\Authentication\\LaminasAuthentication\\',
+            'Zend\\Expressive\\Authentication\\'                     => 'Expressive\\Authentication\\',
             'Zend\\Expressive\\Router\\ZendRouter\\'                 => 'Expressive\\Router\\LaminasRouter\\',
+            'Zend\\Expressive\\Router\\'                             => 'Expressive\\Router\\',
             'Zend\\Expressive\\ZendView\\'                           => 'Expressive\\LaminasView\\',
             'Zend\\Expressive\\'                                     => 'Expressive\\',
             // Laminas


### PR DESCRIPTION
Because we are matching the namespace by segments we need to have
defined rules for all 'previous' segments:
- try to load `A\B\C`
- rewrite rule must be:
```
  - A\B\C => D\E\F
  - A\B   => D\E
  - A     => D
```