### PR TITLE
Rewrite rules to be more generic

### DIFF
--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -18,29 +18,24 @@ class Autoloader
      */
     public static function load()
     {
-        $classes = RewriteRules::classRewrite();
         $namespaces = RewriteRules::namespaceRewrite();
-        spl_autoload_register(function ($class) use ($classes, $namespaces) {
-            if (isset($classes[$class])) {
-                $alias = $classes[$class];
-            } else {
-                $segments = explode('\\', $class);
+        spl_autoload_register(function ($class) use ($namespaces) {
+            $segments = explode('\\', $class);
 
-                $i = 0;
-                $check = '';
+            $i = 0;
+            $check = '';
 
-                // We are checking segments of the namespace to match quicker
-                while (isset($namespaces[$check . $segments[$i] . '\\'])) {
-                    $check .= $segments[$i] . '\\';
-                    ++$i;
-                }
-
-                if ($check === '') {
-                    return;
-                }
-
-                $alias = $namespaces[$check] . substr($class, strlen($check));
+            // We are checking segments of the namespace to match quicker
+            while (isset($namespaces[$check . $segments[$i] . '\\'])) {
+                $check .= $segments[$i] . '\\';
+                ++$i;
             }
+
+            if ($check === '') {
+                return;
+            }
+
+            $alias = $namespaces[$check] . str_replace('Zend', 'Laminas', substr($class, strlen($check)));
 
             if (class_exists($alias) || interface_exists($alias) || trait_exists($alias)) {
                 class_alias($alias, $class);

--- a/src/RewriteRules.php
+++ b/src/RewriteRules.php
@@ -17,16 +17,9 @@ class RewriteRules
         // @todo Need to determine the final name and namespace for zf-console
         return array(
             // Expressive
-            'Zend\\ProblemDetails\\'                                 => 'Expressive\\ProblemDetails\\',
-            'Zend\\Expressive\\Authentication\\ZendAuthentication\\' => 'Expressive\\Authentication\\LaminasAuthentication\\',
-            'Zend\\Expressive\\Authentication\\'                     => 'Expressive\\Authentication\\',
-            'Zend\\Expressive\\Router\\ZendRouter\\'                 => 'Expressive\\Router\\LaminasRouter\\',
-            'Zend\\Expressive\\Router\\'                             => 'Expressive\\Router\\',
-            'Zend\\Expressive\\ZendView\\'                           => 'Expressive\\LaminasView\\',
-            'Zend\\Expressive\\'                                     => 'Expressive\\',
+            'Zend\\ProblemDetails\\' => 'Expressive\\ProblemDetails\\',
+            'Zend\\Expressive\\'     => 'Expressive\\',
             // Laminas
-            'Zend\\Psr7Bridge\\Zend\\'  => 'Laminas\\Psr7Bridge\\Laminas\\',
-            'Zend\\Psr7Bridge\\'        => 'Laminas\\Psr7Bridge\\',
             'Zend\\'                    => 'Laminas\\',
             'ZF\\ComposerAutoloading\\' => 'Laminas\\ComposerAutoloading\\',
             'ZF\\Deploy\\'              => 'Laminas\\Deploy\\',
@@ -39,35 +32,6 @@ class RewriteRules
             'ZendService\\'     => 'Laminas\\',
             'ZendOAuth\\'       => 'Laminas\\OAuth\\',
             'ZendDiagnostics\\' => 'Laminas\\Diagnostics\\',
-        );
-    }
-
-    /**
-     * @return array
-     */
-    public static function classRewrite()
-    {
-        return array(
-            'Zend\\Expressive\\Authentication\\ZendAuthentication\\ZendAuthentication'
-                => 'Expressive\\Authentication\\LaminasAuthentication\\LaminasAuthentication',
-            'Zend\\Expressive\\Authentication\\ZendAuthentication\\ZendAuthenticationFactory'
-                => 'Expressive\\Authentication\\LaminasAuthentication\\LaminasAuthenticationFactory',
-            'Zend\\Expressive\\Authorization\\Acl\\ZendAclFactory'
-                => 'Expressive\\Authorization\\Acl\\LaminasAclFactory',
-            'Zend\\Expressive\\Authorization\\Acl\\ZendAcl'
-                => 'Expressive\\Authorization\\Acl\\LaminasAcl',
-            'Zend\\Expressive\\Authorization\\Rbac\\ZendRbac'
-                => 'Expressive\\Authorization\\Rbac\\LaminasRbac',
-            'Zend\\Expressive\\Authorization\\Rbac\\ZendRbacAssertionInterface'
-                => 'Expressive\\Authorization\\Rbac\\LaminasRbacAssertionInterface',
-            'Zend\\Expressive\\Authorization\\Rbac\\ZendRbacFactory'
-                => 'Expressive\\Authorization\\Rbac\\LaminasRbacFactory',
-            'Zend\\Expressive\\Router\\ZendRouter'
-                => 'Expressive\\Router\\LaminasRouter',
-            'Zend\\Expressive\\ZendView\\ZendViewRenderer'
-                => 'Expressive\\LaminasView\\LaminasViewRenderer',
-            'Zend\\Expressive\\ZendView\\ZendViewRendererFactory'
-                => 'Expressive\\LaminasView\\LaminasViewRendererFactory',
         );
     }
 }

--- a/test/AutoloaderTest.php
+++ b/test/AutoloaderTest.php
@@ -14,22 +14,46 @@ class AutoloaderTest extends TestCase
     public function classProvider()
     {
         return array(
-            array('Zend\Main'),
-            array('Zend\Expressive\Expressive'),
-            array('Zend\Expressive\Authentication\Authentication'),
-            array('Zend\Expressive\Authentication\ZendAuthentication\AuthenticationAdapter'),
-            array('Zend\Expressive\Router\Router'),
-            array('Zend\Expressive\Router\ZendRouter\RouterAdapter'),
-            array('Zend\ProblemDetails\ProblemDetails'),
+            // Expressive
+            array('Zend\Expressive\Expressive',                                              'Expressive\Expressive'),
+            array('Zend\Expressive\Authentication\Authentication',                           'Expressive\Authentication\Authentication'),
+            array('Zend\Expressive\Authentication\ZendAuthentication\AuthenticationAdapter', 'Expressive\Authentication\LaminasAuthentication\AuthenticationAdapter'),
+            array('Zend\Expressive\Authentication\ZendAuthentication\ZendAuthentication',    'Expressive\Authentication\LaminasAuthentication\LaminasAuthentication'),
+            array('Zend\Expressive\Authorization\Authorization',                             'Expressive\Authorization\Authorization'),
+            array('Zend\Expressive\Authorization\Acl\ZendAclFactory',                        'Expressive\Authorization\Acl\LaminasAclFactory'),
+            array('Zend\Expressive\Authorization\Rbac\ZendRbac',                             'Expressive\Authorization\Rbac\LaminasRbac'),
+            array('Zend\Expressive\Router\Router',                                           'Expressive\Router\Router'),
+            array('Zend\Expressive\Router\ZendRouter',                                       'Expressive\Router\LaminasRouter'),
+            array('Zend\Expressive\Router\ZendRouter\RouterAdapter',                         'Expressive\Router\LaminasRouter\RouterAdapter'),
+            array('Zend\Expressive\ZendView\ZendViewRenderer',                               'Expressive\LaminasView\LaminasViewRenderer'),
+            array('Zend\ProblemDetails\ProblemDetails',                                      'Expressive\ProblemDetails\ProblemDetails'),
+            // Laminas
+            array('Zend\Main',                          'Laminas\Main'),
+            array('Zend\Psr7Bridge\Psr7Bridge',         'Laminas\Psr7Bridge\Psr7Bridge'),
+            array('Zend\Psr7Bridge\ZendBridge',         'Laminas\Psr7Bridge\LaminasBridge'),
+            array('Zend\Psr7Bridge\Zend\Psr7Bridge',    'Laminas\Psr7Bridge\Laminas\Psr7Bridge'),
+            array('Zend\Psr7Bridge\Zend\ZendBridge',    'Laminas\Psr7Bridge\Laminas\LaminasBridge'),
+            array('ZendService\Service',                'Laminas\Service'),
+            array('ZendXml\XmlService',                 'Laminas\Xml\XmlService'),
+            array('ZendOAuth\OAuthService',             'Laminas\OAuth\OAuthService'),
+            array('ZendDiagnostics\Tools',              'Laminas\Diagnostics\Tools'),
+            array('ZF\ComposerAutoloading\Autoloading', 'Laminas\ComposerAutoloading\Autoloading'),
+            array('ZF\Deploy\Deploy',                   'Laminas\Deploy\Deploy'),
+            array('ZF\DevelopmentMode\DevelopmentMode', 'Laminas\DevelopmentMode\DevelopmentMode'),
+            // Apigility
+            array('ZF\Apigility\BaseModule', 'Apigility\BaseModule'),
+            array('ZF\BaseModule',           'Apigility\BaseModule'),
         );
     }
 
     /**
      * @dataProvider classProvider
-     * @param string $className
+     * @param string $legacy
+     * @param string $actual
      */
-    public function testLegacyClassIsAliasToLaminas($className)
+    public function testLegacyClassIsAliasToLaminas($legacy, $actual)
     {
-        self::assertTrue(class_exists($className));
+        self::assertTrue(class_exists($legacy));
+        self::assertSame($actual, get_class(new $legacy()));
     }
 }

--- a/test/classes.php
+++ b/test/classes.php
@@ -5,10 +5,6 @@
  * @license   https://github.com/laminas/laminas-zendframework-bridge/blob/master/LICENSE.md New BSD License
  */
 
-namespace Laminas {
-    class Main {}
-}
-
 namespace Expressive {
     class Expressive {}
 }
@@ -19,16 +15,77 @@ namespace Expressive\Authentication {
 
 namespace Expressive\Authentication\LaminasAuthentication {
     class AuthenticationAdapter {}
+    class LaminasAuthentication {}
+}
+
+namespace Expressive\Authorization {
+    class Authorization {}
+}
+
+namespace Expressive\Authorization\Acl {
+    class LaminasAclFactory {}
+}
+
+namespace Expressive\Authorization\Rbac {
+    class LaminasRbac {}
 }
 
 namespace Expressive\Router {
     class Router {}
+    class LaminasRouter {}
 }
 
 namespace Expressive\Router\LaminasRouter {
     class RouterAdapter {}
 }
 
+namespace Expressive\LaminasView {
+    class LaminasViewRenderer {}
+}
+
 namespace Expressive\ProblemDetails {
     class ProblemDetails {}
+}
+
+namespace Laminas {
+    class Main {}
+    class Service {}
+}
+
+namespace Laminas\Psr7Bridge {
+    class Psr7Bridge {}
+    class LaminasBridge {}
+}
+
+namespace Laminas\Psr7Bridge\Laminas {
+    class Psr7Bridge {}
+    class LaminasBridge {}
+}
+
+namespace Laminas\ComposerAutoloading {
+    class Autoloading {}
+}
+
+namespace Laminas\Deploy {
+    class Deploy {}
+}
+
+namespace Laminas\DevelopmentMode {
+    class DevelopmentMode {}
+}
+
+namespace Apigility {
+    class BaseModule {}
+}
+
+namespace Laminas\Xml {
+    class XmlService {}
+}
+
+namespace Laminas\OAuth {
+    class OAuthService {}
+}
+
+namespace Laminas\Diagnostics {
+    class Tools {}
 }


### PR DESCRIPTION
We don't need to specify classes or namespaces with `Zend` as these are going to be changed to `Laminas` automatically.

__Updated tests:__ added tests to cover all cases, also check the original class name - so we know if autoloader works as we expect.
