### PR TITLE
Adds typehints compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,10 @@
             "test/classes.php"
         ],
         "psr-4": {
-            "LaminasTest\\ZendFrameworkBridge\\": "test//"
+            "LaminasTest\\ZendFrameworkBridge\\": "test//",
+            "Apigility\\": "test//TestAsset//Apigility//",
+            "Expressive\\": "test//TestAsset//Expressive//",
+            "Laminas\\": "test//TestAsset//Laminas//"
         }
     },
     "extra": {

--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -38,7 +38,7 @@ class Autoloader
             $i = 0;
             $check = '';
 
-            while (isset($namespaces[$check . $segments[$i] . '\\'])) {
+            while (isset($segments[$i + 1], $namespaces[$check . $segments[$i] . '\\'])) {
                 $check .= $segments[$i] . '\\';
                 ++$i;
             }
@@ -61,7 +61,7 @@ class Autoloader
             $check = '';
 
             // We are checking segments of the namespace to match quicker
-            while (isset($namespaces[$check . $segments[$i] . '\\'])) {
+            while (isset($segments[$i + 1], $namespaces[$check . $segments[$i] . '\\'])) {
                 $check .= $segments[$i] . '\\';
                 ++$i;
             }

--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -18,8 +18,39 @@ class Autoloader
      */
     public static function load()
     {
+        static $loaded = array();
+
+        $classLoader = self::getClassLoader();
+
         $namespaces = RewriteRules::namespaceRewrite();
-        spl_autoload_register(function ($class) use ($namespaces) {
+        spl_autoload_register(function ($class) use ($namespaces, $classLoader, &$loaded) {
+            if (isset($loaded[$class])) {
+                return;
+            }
+
+            // @todo: we need here reverse mapping:
+            //    from new class names we need to get old class name
+            //    that we can add alias - then typehints can work
+            //    as expected.
+            if (strpos($class, 'Expressive\\') === 0) {
+                if ($file = $classLoader->findFile($class)) {
+                    \Composer\Autoload\includeFile($file);
+                    class_alias($class, 'Zend\\' . $class, false);
+                }
+            } elseif (strpos($class, 'Laminas\\') === 0) {
+                if ($file = $classLoader->findFile($class)) {
+                    \Composer\Autoload\includeFile($file);
+                    class_alias($class, str_replace('Laminas\\', 'Zend\\', $class), false);
+                }
+            } elseif (strpos($class, 'Apigility\\') === 0) {
+                if ($file = $classLoader->findFile($class)) {
+                    \Composer\Autoload\includeFile($file);
+                    class_alias($class, 'ZF\\' . $class);
+                }
+            }
+        }, true, true);
+
+        spl_autoload_register(function ($class) use ($namespaces, &$loaded) {
             $segments = explode('\\', $class);
 
             $i = 0;
@@ -37,9 +68,23 @@ class Autoloader
 
             $alias = $namespaces[$check] . str_replace('Zend', 'Laminas', substr($class, strlen($check)));
 
+            $loaded[$alias] = true;
             if (class_exists($alias) || interface_exists($alias) || trait_exists($alias)) {
                 class_alias($alias, $class);
             }
         });
+    }
+
+    private static function getClassLoader()
+    {
+        if (file_exists(__DIR__ . '/../../../autoload.php')) {
+            return include __DIR__ . '/../../../autoload.php';
+        }
+
+        if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+            return include __DIR__ . '/../vendor/autoload.php';
+        }
+
+        throw new \RuntimeException('Cannot detect composer autoload. Please run composer install');
     }
 }

--- a/src/RewriteRules.php
+++ b/src/RewriteRules.php
@@ -34,4 +34,45 @@ class RewriteRules
             'ZendDiagnostics\\' => 'Laminas\\Diagnostics\\',
         );
     }
+
+    /**
+     * @return array
+     */
+    public static function namespaceReverse()
+    {
+        return array(
+            // ZendXml, ZendOAuth, ZendDiagnostics
+            'Laminas\\Xml\\' => 'ZendXml\\',
+            'Laminas\\OAuth\\' => 'ZendOAuth\\',
+            'Laminas\\Diagnostics\\' => 'ZendDiagnostics\\',
+
+            // Zend Service
+            'Laminas\\Amazon\\' => 'ZendService\\Amazon\\',
+            'Laminas\\Apple\\' => 'ZendService\\Apple\\',
+            'Laminas\\Google\\' => 'ZendService\\Google\\',
+            'Laminas\\ReCaptcha\\' => 'ZendService\\ReCaptcha\\',
+            'Laminas\\Twitter\\' => 'ZendService\\Twitter\\',
+
+            // Zend
+            'Laminas\\' => 'Zend\\',
+
+            // Expressive
+            'Expressive\\ProblemDetails\\' => 'Zend\\ProblemDetails\\',
+            'Expressive\\' => 'Zend\\Expressive\\',
+
+            // Laminas to ZfCampus
+            'Laminas\\ComposerAutoloading\\' => 'ZF\\ComposerAutoloading\\',
+            'Laminas\\Deploy\\' => 'ZF\\Deploy\\',
+            'Laminas\\DevelopmentMode\\' => 'ZF\\DevelopmentMode\\',
+
+            // Apigility
+            'Apigility\\Admin\\' => 'ZF\\Apigility\\Admin\\',
+            'Apigility\\Doctrine\\' => 'ZF\\Apigility\\Doctrine\\',
+            'Apigility\\Documentation\\' => 'ZF\\Apigility\\Documentation\\',
+            'Apigility\\Example\\' => 'ZF\\Apigility\\Example\\',
+            'Apigility\\Provider\\' => 'ZF\\Apigility\\Provider\\',
+            'Apigility\\Welcome\\' => 'ZF\\Apiglity\\Welcome\\',
+            'Apigility\\' => 'ZF\\',
+        );
+    }
 }

--- a/test/AutoloaderTest.php
+++ b/test/AutoloaderTest.php
@@ -32,6 +32,7 @@ class AutoloaderTest extends TestCase
             array('Zend\Expressive\ZendView\ZendViewRenderer',                               'Expressive\LaminasView\LaminasViewRenderer'),
             array('Zend\ProblemDetails\ProblemDetails',                                      'Expressive\ProblemDetails\ProblemDetails'),
             // Laminas
+            array('Zend\Expressive',                    'Laminas\Expressive'),
             array('Zend\Main',                          'Laminas\Main'),
             array('Zend\Psr7Bridge\Psr7Bridge',         'Laminas\Psr7Bridge\Psr7Bridge'),
             array('Zend\Psr7Bridge\ZendBridge',         'Laminas\Psr7Bridge\LaminasBridge'),

--- a/test/AutoloaderTest.php
+++ b/test/AutoloaderTest.php
@@ -7,6 +7,7 @@
 
 namespace LaminasTest\ZendFrameworkBridge;
 
+use Laminas\LegacyTypeHint;
 use PHPUnit\Framework\TestCase;
 
 class AutoloaderTest extends TestCase
@@ -55,5 +56,11 @@ class AutoloaderTest extends TestCase
     {
         self::assertTrue(class_exists($legacy));
         self::assertSame($actual, get_class(new $legacy()));
+    }
+
+    public function testTypeHint()
+    {
+        self::assertTrue(class_exists('Laminas\LegacyTypeHint'));
+        new LegacyTypeHint(new \Laminas\Example());
     }
 }

--- a/test/AutoloaderTest.php
+++ b/test/AutoloaderTest.php
@@ -12,6 +12,9 @@ use PHPUnit\Framework\TestCase;
 
 class AutoloaderTest extends TestCase
 {
+    /**
+     * @return array[]
+     */
     public function classProvider()
     {
         return array(
@@ -62,5 +65,55 @@ class AutoloaderTest extends TestCase
     {
         self::assertTrue(class_exists('Laminas\LegacyTypeHint'));
         new LegacyTypeHint(new \Laminas\Example());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function reverseClassProvider()
+    {
+        return array(
+            // Apigility
+            array('Apigility\Admin\Example',         'ZF\Apigility\Admin\Example'),
+            array('Apigility\Doctrine\Example',      'ZF\Apigility\Doctrine\Example'),
+            array('Apigility\Documentation\Example', 'ZF\Apigility\Documentation\Example'),
+            array('Apigility\Example\Example',       'ZF\Apigility\Example\Example'),
+            array('Apigility\Provider\Example',      'ZF\Apigility\Provider\Example'),
+            array('Apigility\Welcome\Example',       'ZF\Apigility\Welcome\Example'),
+            array('Apigility\Other\Example',         'ZF\Other\Example'),
+            array('Apigility\Example',               'ZF\Example'),
+
+            // Expressive
+            array('Expressive\ProblemDetails\Example', 'Zend\ProblemDetails\Example'),
+            array('Expressive\Other\Example',          'Zend\Expressive\Other\Example'),
+            array('Expressive\Example',                'Zend\Expressive\Example'),
+
+            // Laminas
+            array('Laminas\Amazon\Example',              'ZendService\Amazon\Example'),
+            array('Laminas\Apple\Example',               'ZendService\Apple\Example'),
+            array('Laminas\Google\Example',              'ZendService\Google\Example'),
+            array('Laminas\ReCaptcha\Example',           'ZendService\ReCaptcha\Example'),
+            array('Laminas\Twitter\Example',             'ZendService\Twitter\Example'),
+            array('Laminas\ComposerAutoloading\Example', 'ZF\ComposerAutoloading\Example'),
+            array('Laminas\Deploy\Example',              'ZF\Deploy\Example'),
+            array('Laminas\DevelopmentMode\Example',     'ZF\DevelopmentMode\Example'),
+            array('Laminas\Diagnostics\Example',         'ZendDiagnostics\Example'),
+            array('Laminas\OAuth\Example',               'ZendOAuth\Example'),
+            array('Laminas\Xml\Example',                 'ZendXml\Example'),
+            array('Laminas\Other\LaminasExample',        'Zend\Other\ZendExample'),
+            array('Laminas\Other\Example',               'Zend\Other\Example'),
+            array('Laminas\Example',                     'Zend\Example'),
+        );
+    }
+
+    /**
+     * @dataProvider reverseClassProvider
+     * @param string $actual
+     * @param string $legacy
+     */
+    public function testReverseAliasCreated($actual, $legacy)
+    {
+        self::assertTrue(class_exists($actual));
+        self::assertTrue(class_exists($legacy));
     }
 }

--- a/test/TestAsset/Apigility/Admin/Example.php
+++ b/test/TestAsset/Apigility/Admin/Example.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Apigility\Admin;
+
+class Example
+{
+}

--- a/test/TestAsset/Apigility/Doctrine/Example.php
+++ b/test/TestAsset/Apigility/Doctrine/Example.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Apigility\Doctrine;
+
+class Example
+{
+}

--- a/test/TestAsset/Apigility/Documentation/Example.php
+++ b/test/TestAsset/Apigility/Documentation/Example.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Apigility\Documentation;
+
+class Example
+{
+}

--- a/test/TestAsset/Apigility/Example.php
+++ b/test/TestAsset/Apigility/Example.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Apigility;
+
+class Example
+{
+}

--- a/test/TestAsset/Apigility/Example/Example.php
+++ b/test/TestAsset/Apigility/Example/Example.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Apigility\Example;
+
+class Example
+{
+}

--- a/test/TestAsset/Apigility/Other/Example.php
+++ b/test/TestAsset/Apigility/Other/Example.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Apigility\Other;
+
+class Example
+{
+}

--- a/test/TestAsset/Apigility/Provider/Example.php
+++ b/test/TestAsset/Apigility/Provider/Example.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Apigility\Provider;
+
+class Example
+{
+}

--- a/test/TestAsset/Apigility/Welcome/Example.php
+++ b/test/TestAsset/Apigility/Welcome/Example.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Apigility\Welcome;
+
+class Example
+{
+}

--- a/test/TestAsset/Expressive/Example.php
+++ b/test/TestAsset/Expressive/Example.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Expressive;
+
+class Example
+{
+}

--- a/test/TestAsset/Expressive/Other/Example.php
+++ b/test/TestAsset/Expressive/Other/Example.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Expressive\Other;
+
+class Example
+{
+}

--- a/test/TestAsset/Expressive/ProblemDetails/Example.php
+++ b/test/TestAsset/Expressive/ProblemDetails/Example.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Expressive\ProblemDetails;
+
+class Example
+{
+}

--- a/test/TestAsset/Laminas/Amazon/Example.php
+++ b/test/TestAsset/Laminas/Amazon/Example.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Laminas\Amazon;
+
+class Example
+{
+}

--- a/test/TestAsset/Laminas/Apple/Example.php
+++ b/test/TestAsset/Laminas/Apple/Example.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Laminas\Apple;
+
+class Example
+{
+}

--- a/test/TestAsset/Laminas/ComposerAutoloading/Example.php
+++ b/test/TestAsset/Laminas/ComposerAutoloading/Example.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Laminas\ComposerAutoloading;
+
+class Example
+{
+}

--- a/test/TestAsset/Laminas/Deploy/Example.php
+++ b/test/TestAsset/Laminas/Deploy/Example.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Laminas\Deploy;
+
+class Example
+{
+}

--- a/test/TestAsset/Laminas/DevelopmentMode/Example.php
+++ b/test/TestAsset/Laminas/DevelopmentMode/Example.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Laminas\DevelopmentMode;
+
+class Example
+{
+}

--- a/test/TestAsset/Laminas/Diagnostics/Example.php
+++ b/test/TestAsset/Laminas/Diagnostics/Example.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Laminas\Diagnostics;
+
+class Example
+{
+}

--- a/test/TestAsset/Laminas/Example.php
+++ b/test/TestAsset/Laminas/Example.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Laminas;
+
+class Example
+{
+}

--- a/test/TestAsset/Laminas/Google/Example.php
+++ b/test/TestAsset/Laminas/Google/Example.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Laminas\Google;
+
+class Example
+{
+}

--- a/test/TestAsset/Laminas/LegacyTypeHint.php
+++ b/test/TestAsset/Laminas/LegacyTypeHint.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laminas;
+
+class LegacyTypeHint
+{
+    public function __construct(\Zend\Example $example)
+    {
+    }
+}

--- a/test/TestAsset/Laminas/OAuth/Example.php
+++ b/test/TestAsset/Laminas/OAuth/Example.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Laminas\OAuth;
+
+class Example
+{
+}

--- a/test/TestAsset/Laminas/Other/Example.php
+++ b/test/TestAsset/Laminas/Other/Example.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Laminas\Other;
+
+class Example
+{
+}

--- a/test/TestAsset/Laminas/Other/LaminasExample.php
+++ b/test/TestAsset/Laminas/Other/LaminasExample.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Laminas\Other;
+
+class LaminasExample
+{
+}

--- a/test/TestAsset/Laminas/ReCaptcha/Example.php
+++ b/test/TestAsset/Laminas/ReCaptcha/Example.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Laminas\ReCaptcha;
+
+class Example
+{
+}

--- a/test/TestAsset/Laminas/Twitter/Example.php
+++ b/test/TestAsset/Laminas/Twitter/Example.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Laminas\Twitter;
+
+class Example
+{
+}

--- a/test/TestAsset/Laminas/Xml/Example.php
+++ b/test/TestAsset/Laminas/Xml/Example.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Laminas\Xml;
+
+class Example
+{
+}

--- a/test/classes.php
+++ b/test/classes.php
@@ -48,6 +48,7 @@ namespace Expressive\ProblemDetails {
 }
 
 namespace Laminas {
+    class Expressive {}
     class Main {}
     class Service {}
 }


### PR DESCRIPTION
User code and 3rd party libraries still use legacy typehints. If we try to load new class and corresponding legacy class was not loaded before then we can get error of typehints incompatibility. On loading new class we need then create alias to legacy class so PHP interpreter thinks that it's the same class and we can have seamless migration.

**TODO:**

- [x] Add reverse mapping for all namespaces
- [x] Change autoloader to use above reverse mapping
- [x] Add tests for all cases (reverse mapping)