### PR TITLE
Removes rewrite for ZendService_* (Amazon, Apple_Apns, Google_Gcm)

### DIFF
--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -111,6 +111,12 @@ class Autoloader
         return function ($class) use ($namespaces, $loaded) {
             $segments = explode('\\', $class);
 
+            if ($segments[0] === 'ZendService' && isset($segments[1])) {
+                $segments[0] .= '\\' . $segments[1];
+                unset($segments[1]);
+                $segments = array_values($segments);
+            }
+
             $i = 0;
             $check = '';
 

--- a/src/RewriteRules.php
+++ b/src/RewriteRules.php
@@ -14,7 +14,6 @@ class RewriteRules
      */
     public static function namespaceRewrite()
     {
-        // @todo Need to determine the final name and namespace for zf-console
         return array(
             // Expressive
             'Zend\\ProblemDetails\\' => 'Expressive\\ProblemDetails\\',
@@ -31,10 +30,11 @@ class RewriteRules
             'ZF\\'            => 'Apigility\\',
 
             // ZendXml, API wrappers, zend-http OAuth support, zend-diagnostics
-            'ZendXml\\'         => 'Laminas\\Xml\\',
-            'ZendService\\'     => 'Laminas\\',
-            'ZendOAuth\\'       => 'Laminas\\OAuth\\',
-            'ZendDiagnostics\\' => 'Laminas\\Diagnostics\\',
+            'ZendXml\\'                => 'Laminas\\Xml\\',
+            'ZendOAuth\\'              => 'Laminas\\OAuth\\',
+            'ZendDiagnostics\\'        => 'Laminas\\Diagnostics\\',
+            'ZendService\\ReCaptcha\\' => 'Laminas\\ReCaptcha\\',
+            'ZendService\\Twitter\\'   => 'Laminas\\Twitter\\',
         );
     }
 
@@ -50,8 +50,6 @@ class RewriteRules
             'Laminas\\Diagnostics\\' => 'ZendDiagnostics\\',
 
             // Zend Service
-            'Laminas\\Apple\\'     => 'ZendService\\Apple\\',
-            'Laminas\\Google\\'    => 'ZendService\\Google\\',
             'Laminas\\ReCaptcha\\' => 'ZendService\\ReCaptcha\\',
             'Laminas\\Twitter\\'   => 'ZendService\\Twitter\\',
 

--- a/src/RewriteRules.php
+++ b/src/RewriteRules.php
@@ -50,7 +50,6 @@ class RewriteRules
             'Laminas\\Diagnostics\\' => 'ZendDiagnostics\\',
 
             // Zend Service
-            'Laminas\\Amazon\\'    => 'ZendService\\Amazon\\',
             'Laminas\\Apple\\'     => 'ZendService\\Apple\\',
             'Laminas\\Google\\'    => 'ZendService\\Google\\',
             'Laminas\\ReCaptcha\\' => 'ZendService\\ReCaptcha\\',

--- a/test/AutoloaderTest.php
+++ b/test/AutoloaderTest.php
@@ -38,7 +38,8 @@ class AutoloaderTest extends TestCase
             array('Zend\Psr7Bridge\ZendBridge',         'Laminas\Psr7Bridge\LaminasBridge'),
             array('Zend\Psr7Bridge\Zend\Psr7Bridge',    'Laminas\Psr7Bridge\Laminas\Psr7Bridge'),
             array('Zend\Psr7Bridge\Zend\ZendBridge',    'Laminas\Psr7Bridge\Laminas\LaminasBridge'),
-            array('ZendService\Service',                'Laminas\Service'),
+            array('ZendService\ReCaptcha\MyClass',      'Laminas\ReCaptcha\MyClass'),
+            array('ZendService\Twitter\MyClass',        'Laminas\Twitter\MyClass'),
             array('ZendXml\XmlService',                 'Laminas\Xml\XmlService'),
             array('ZendOAuth\OAuthService',             'Laminas\OAuth\OAuthService'),
             array('ZendDiagnostics\Tools',              'Laminas\Diagnostics\Tools'),
@@ -90,8 +91,6 @@ class AutoloaderTest extends TestCase
             array('Expressive\Example',                'Zend\Expressive\Example'),
 
             // Laminas
-            array('Laminas\Apple\Example',               'ZendService\Apple\Example'),
-            array('Laminas\Google\Example',              'ZendService\Google\Example'),
             array('Laminas\ReCaptcha\Example',           'ZendService\ReCaptcha\Example'),
             array('Laminas\Twitter\Example',             'ZendService\Twitter\Example'),
             array('Laminas\ComposerAutoloading\Example', 'ZF\ComposerAutoloading\Example'),

--- a/test/AutoloaderTest.php
+++ b/test/AutoloaderTest.php
@@ -90,7 +90,6 @@ class AutoloaderTest extends TestCase
             array('Expressive\Example',                'Zend\Expressive\Example'),
 
             // Laminas
-            array('Laminas\Amazon\Example',              'ZendService\Amazon\Example'),
             array('Laminas\Apple\Example',               'ZendService\Apple\Example'),
             array('Laminas\Google\Example',              'ZendService\Google\Example'),
             array('Laminas\ReCaptcha\Example',           'ZendService\ReCaptcha\Example'),

--- a/test/TestAsset/Laminas/Amazon/Example.php
+++ b/test/TestAsset/Laminas/Amazon/Example.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Laminas\Amazon;
-
-class Example
-{
-}

--- a/test/TestAsset/Laminas/Apple/Example.php
+++ b/test/TestAsset/Laminas/Apple/Example.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Laminas\Apple;
-
-class Example
-{
-}

--- a/test/TestAsset/Laminas/Google/Example.php
+++ b/test/TestAsset/Laminas/Google/Example.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Laminas\Google;
-
-class Example
-{
-}

--- a/test/classes.php
+++ b/test/classes.php
@@ -75,6 +75,14 @@ namespace Laminas\DevelopmentMode {
     class DevelopmentMode {}
 }
 
+namespace Laminas\ReCaptcha {
+    class MyClass {}
+}
+
+namespace Laminas\Twitter {
+    class MyClass {}
+}
+
 namespace Apigility {
     class BaseModule {}
 }


### PR DESCRIPTION
@weierophinney As we discussed recently these packages are not going to be transferred to Laminas. We can drop the rewrite for these namespaces here.

Adds specific rules for `ZendService\Twitter` and `ZendService\ReCaptcha` as only these two libraries of ZendService are going to be transferred.