### PR TITLE
Hotfix: adds missing rewrite rules - ZendAcl, ZendRbac

### DIFF
--- a/config/replacements.php
+++ b/config/replacements.php
@@ -157,6 +157,8 @@ return [
     'Zend\\Expressive' => 'Expressive',
     'Zend\\\\Expressive' => 'Expressive',
     'ZendAuthentication' => 'LaminasAuthentication',
+    'ZendAcl' => 'LaminasAcl',
+    'ZendRbac' => 'LaminasRbac',
     'ZendRouter' => 'LaminasRouter',
 
     // Apigility


### PR DESCRIPTION
We missed some rewrite rules:
ZendAcl => LaminasAcl
ZendRbac => LaminasRbac

See:
- https://github.com/zendframework/zend-expressive-authorization-acl/tree/master/src
- https://github.com/zendframework/zend-expressive-authorization-rbac/tree/master/src