### PR TITLE
Hotfix: do not rewrite Doctrine\Zend

### DIFF
--- a/config/replacements.php
+++ b/config/replacements.php
@@ -3,6 +3,7 @@
 return [
     // NEVER REWRITE
     'zendframework/zendframework' => 'zendframework/zendframework',
+    'Doctrine\\Zend' => 'Doctrine\\Zend',
 
     // NAMESPACES
     // Zend Framework components


### PR DESCRIPTION
We do not want to rewrite namespace `Doctrine\Zend`.
See: https://github.com/doctrine/doctrine-zend-hydrator