### PR TITLE
Rename text component flf file references

### DIFF
--- a/config/replacements.php
+++ b/config/replacements.php
@@ -344,6 +344,7 @@ return [
     'ZendValidator' => 'LaminasValidator',
     'zendview' => 'laminasview',
     'ZendView' => 'LaminasView',
+    'zend-framework.flf' => 'laminas-project.flf',
 
     // Expressive-related
     "'zend-expressive'" => "'expressive'",


### PR DESCRIPTION
Per a report from a user attempting migration, the text component contains a file named `zend-framework.flf`, which should be renamed to `laminas-project.flf`.