### PR TITLE
Rewrite "zenddevelopertools" to "laminas-developer-tools"

### DIFF
--- a/config/replacements.php
+++ b/config/replacements.php
@@ -309,7 +309,7 @@ return [
     'zend-config' => 'laminas-config',
     'zend-developer-tools/' => 'laminas-developer-tools/',
     'zend-tag-cloud' => 'laminas-tag-cloud',
-    'zenddevelopertools' => 'laminasdevelopertools',
+    'zenddevelopertools' => 'laminas-developer-tools',
     'zendbarcode' => 'laminasbarcode',
     'ZendBarcode' => 'LaminasBarcode',
     'zendcache' => 'laminascache',


### PR DESCRIPTION
Per feedback when testing the migration tooling, we need to rewrite "zenddevelopertools" to "laminas-developer-tools".