### PR TITLE
Hotfix: ZendDeveloperTools namespace rewrite rules

### DIFF
--- a/config/replacements.php
+++ b/config/replacements.php
@@ -25,7 +25,7 @@ return [
     'Zend\\Crypt' => 'Laminas\\Crypt',
     'Zend\\Db' => 'Laminas\\Db',
     'Zend\\Debug' => 'Laminas\\Debug',
-    'ZendDeveloperTools' => 'LaminasDeveloperTools',
+    'ZendDeveloperTools' => 'Laminas\\DeveloperTools',
     'Zend\\Di' => 'Laminas\\Di',
     'Zend\\Diactoros' => 'Laminas\\Diactoros',
     'ZendDiagnostics\\Check' => 'Laminas\\Diagnostics\\Check',

--- a/src/RewriteRules.php
+++ b/src/RewriteRules.php
@@ -29,12 +29,13 @@ class RewriteRules
             'ZF\\Apigility\\' => 'Apigility\\',
             'ZF\\'            => 'Apigility\\',
 
-            // ZendXml, API wrappers, zend-http OAuth support, zend-diagnostics
+            // ZendXml, API wrappers, zend-http OAuth support, zend-diagnostics, ZendDeveloperTools
             'ZendXml\\'                => 'Laminas\\Xml\\',
             'ZendOAuth\\'              => 'Laminas\\OAuth\\',
             'ZendDiagnostics\\'        => 'Laminas\\Diagnostics\\',
             'ZendService\\ReCaptcha\\' => 'Laminas\\ReCaptcha\\',
             'ZendService\\Twitter\\'   => 'Laminas\\Twitter\\',
+            'ZendDeveloperTools\\'     => 'Laminas\\DeveloperTools\\',
         );
     }
 
@@ -44,10 +45,11 @@ class RewriteRules
     public static function namespaceReverse()
     {
         return array(
-            // ZendXml, ZendOAuth, ZendDiagnostics
-            'Laminas\\Xml\\'         => 'ZendXml\\',
-            'Laminas\\OAuth\\'       => 'ZendOAuth\\',
-            'Laminas\\Diagnostics\\' => 'ZendDiagnostics\\',
+            // ZendXml, ZendOAuth, ZendDiagnostics, ZendDeveloperTools
+            'Laminas\\Xml\\'            => 'ZendXml\\',
+            'Laminas\\OAuth\\'          => 'ZendOAuth\\',
+            'Laminas\\Diagnostics\\'    => 'ZendDiagnostics\\',
+            'Laminas\\DeveloperTools\\' => 'ZendDeveloperTools\\',
 
             // Zend Service
             'Laminas\\ReCaptcha\\' => 'ZendService\\ReCaptcha\\',

--- a/test/AutoloaderTest.php
+++ b/test/AutoloaderTest.php
@@ -43,6 +43,7 @@ class AutoloaderTest extends TestCase
             array('ZendXml\XmlService',                 'Laminas\Xml\XmlService'),
             array('ZendOAuth\OAuthService',             'Laminas\OAuth\OAuthService'),
             array('ZendDiagnostics\Tools',              'Laminas\Diagnostics\Tools'),
+            array('ZendDeveloperTools\Tools',           'Laminas\DeveloperTools\Tools'),
             array('ZF\ComposerAutoloading\Autoloading', 'Laminas\ComposerAutoloading\Autoloading'),
             array('ZF\Deploy\Deploy',                   'Laminas\Deploy\Deploy'),
             array('ZF\DevelopmentMode\DevelopmentMode', 'Laminas\DevelopmentMode\DevelopmentMode'),
@@ -102,6 +103,7 @@ class AutoloaderTest extends TestCase
             array('Laminas\Other\LaminasExample',        'Zend\Other\ZendExample'),
             array('Laminas\Other\Example',               'Zend\Other\Example'),
             array('Laminas\Example',                     'Zend\Example'),
+            array('Laminas\DeveloperTools\Example',      'ZendDeveloperTools\Example'),
         );
     }
 

--- a/test/TestAsset/Laminas/DeveloperTools/Example.php
+++ b/test/TestAsset/Laminas/DeveloperTools/Example.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Laminas\DeveloperTools;
+
+class Example
+{
+}

--- a/test/classes.php
+++ b/test/classes.php
@@ -98,3 +98,7 @@ namespace Laminas\OAuth {
 namespace Laminas\Diagnostics {
     class Tools {}
 }
+
+namespace Laminas\DeveloperTools {
+    class Tools {}
+}


### PR DESCRIPTION
Rewrite `ZendDeveloperTools` namespace to `Laminas\DeveloperTools`.