### PR TITLE
QA: Update Travis CI config - use stable PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,7 @@ matrix:
         - TEST_COVERAGE=true
         - CS_CHECK=true
     - php: 7.3
-    - php: 7.4snapshot
-  allow_failures:
-    - php: 7.4snapshot
+    - php: 7.4
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi


### PR DESCRIPTION
We have now Stable PHP 7.4 on Travis !