### PR TITLE
Rename classes prefixed with Apigility

### DIFF
--- a/config/replacements.php
+++ b/config/replacements.php
@@ -200,6 +200,9 @@ return [
     'ZF\\\\Rest' => 'Laminas\\\\ApiTools\\\\Rest',
     'ZF\\\\Rpc' => 'Laminas\\\\ApiTools\\\\Rpc',
     'ZF\\\\Versioning' => 'Laminas\\\\ApiTools\\\\Versioning',
+    'ApigilityModuleInterface' => 'ApiToolsModuleInterface',
+    'ApigilityProviderInterface' => 'ApiToolsProviderInterface',
+    'ApigilityVersionController' => 'ApiToolsVersionController',
 
     // PACKAGES
     // ZF components, MVC

--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -94,7 +94,12 @@ class Autoloader
             }
 
             if ($classLoader->loadClass($class)) {
-                $legacy = $namespaces[$check] . str_replace('Laminas', 'Zend', substr($class, strlen($check)));
+                $legacy = $namespaces[$check]
+                    . strtr(substr($class, strlen($check)), [
+                        'ApiTools' => 'Apigility',
+                        'Mezzio' => 'Expressive',
+                        'Laminas' => 'Zend',
+                    ]);
                 class_alias($class, $legacy);
             }
         };
@@ -131,7 +136,12 @@ class Autoloader
                 return;
             }
 
-            $alias = $namespaces[$check] . str_replace('Zend', 'Laminas', substr($class, strlen($check)));
+            $alias = $namespaces[$check]
+                . strtr(substr($class, strlen($check)), [
+                    'Apigility' => 'ApiTools',
+                    'Expressive' => 'Mezzio',
+                    'Zend' => 'Laminas',
+                ]);
 
             $loaded[$alias] = true;
             if (class_exists($alias) || interface_exists($alias) || trait_exists($alias)) {

--- a/test/AutoloaderTest.php
+++ b/test/AutoloaderTest.php
@@ -97,12 +97,14 @@ class AutoloaderTest extends TestCase
             ['Laminas\ApiTools\Example\Example',       'ZF\Apigility\Example\Example'],
             ['Laminas\ApiTools\Provider\Example',      'ZF\Apigility\Provider\Example'],
             ['Laminas\ApiTools\Welcome\Example',       'ZF\Apigility\Welcome\Example'],
+            ['Laminas\ApiTools\Other\ApiToolsClass',   'ZF\Other\ApigilityClass'],
             ['Laminas\ApiTools\Other\Example',         'ZF\Other\Example'],
             ['Laminas\ApiTools\Example',               'ZF\Example'],
 
             // Expressive
             ['Mezzio\ProblemDetails\Example', 'Zend\ProblemDetails\Example'],
             ['Mezzio\Other\Example',          'Zend\Expressive\Other\Example'],
+            ['Mezzio\Other\MezzioClass',      'Zend\Expressive\Other\ExpressiveClass'],
             ['Mezzio\Example',                'Zend\Expressive\Example'],
 
             // Laminas
@@ -118,6 +120,7 @@ class AutoloaderTest extends TestCase
             ['Laminas\Other\Example',               'Zend\Other\Example'],
             ['Laminas\Example',                     'Zend\Example'],
             ['Laminas\DeveloperTools\Example',      'ZendDeveloperTools\Example'],
+            ['Laminas\Router\LaminasRouterClass',   'Zend\Router\ZendRouterClass'],
         ];
     }
 

--- a/test/AutoloaderTest.php
+++ b/test/AutoloaderTest.php
@@ -54,11 +54,13 @@ class AutoloaderTest extends TestCase
             ['ZF\DevelopmentMode\DevelopmentMode', 'Laminas\DevelopmentMode\DevelopmentMode'],
 
             // Apigility
+            // phpcs:disable Generic.Files.LineLength.TooLong
             ['ZF\Apigility\BaseModule',        'Laminas\ApiTools\BaseModule'],
             ['ZF\BaseModule',                  'Laminas\ApiTools\BaseModule'],
             ['ZF\Apigility\Admin\Controller\ApigilityVersionController', 'Laminas\ApiTools\Admin\Controller\ApiToolsVersionController'],
             ['ZF\Apigility\ApigilityModuleInterface', 'Laminas\ApiTools\ApiToolsModuleInterface', true],
             ['ZF\Apigility\Provider\ApigilityProviderInterface', 'Laminas\ApiTools\Provider\ApiToolsProviderInterface', true],
+            // phpcs:enable
         ];
     }
 

--- a/test/AutoloaderTest.php
+++ b/test/AutoloaderTest.php
@@ -33,10 +33,11 @@ class AutoloaderTest extends TestCase
             ['Zend\Expressive\Router\ZendRouter\RouterAdapter',                         'Mezzio\Router\LaminasRouter\RouterAdapter'],
             ['Zend\Expressive\ZendView\ZendViewRenderer',                               'Mezzio\LaminasView\LaminasViewRenderer'],
             ['Zend\ProblemDetails\ProblemDetails',                                      'Mezzio\ProblemDetails\ProblemDetails'],
+            ['Zend\Expressive\Hal\ExpressiveUrlGenerator',                              'Mezzio\Hal\MezzioUrlGenerator'],
             // phpcs:enable
 
             // Laminas
-            ['Zend\Expressive',                    'Laminas\Expressive'],
+            ['Zend\Expressive',                    'Laminas\Mezzio'],
             ['Zend\Main',                          'Laminas\Main'],
             ['Zend\Psr7Bridge\Psr7Bridge',         'Laminas\Psr7Bridge\Psr7Bridge'],
             ['Zend\Psr7Bridge\ZendBridge',         'Laminas\Psr7Bridge\LaminasBridge'],
@@ -53,8 +54,9 @@ class AutoloaderTest extends TestCase
             ['ZF\DevelopmentMode\DevelopmentMode', 'Laminas\DevelopmentMode\DevelopmentMode'],
 
             // Apigility
-            ['ZF\Apigility\BaseModule', 'Laminas\ApiTools\BaseModule'],
-            ['ZF\BaseModule',           'Laminas\ApiTools\BaseModule'],
+            ['ZF\Apigility\BaseModule',        'Laminas\ApiTools\BaseModule'],
+            ['ZF\BaseModule',                  'Laminas\ApiTools\BaseModule'],
+            ['ZF\Apigility\ApigilityProvider', 'Laminas\ApiTools\ApiToolsProvider'],
         ];
     }
 

--- a/test/AutoloaderTest.php
+++ b/test/AutoloaderTest.php
@@ -33,7 +33,7 @@ class AutoloaderTest extends TestCase
             ['Zend\Expressive\Router\ZendRouter\RouterAdapter',                         'Mezzio\Router\LaminasRouter\RouterAdapter'],
             ['Zend\Expressive\ZendView\ZendViewRenderer',                               'Mezzio\LaminasView\LaminasViewRenderer'],
             ['Zend\ProblemDetails\ProblemDetails',                                      'Mezzio\ProblemDetails\ProblemDetails'],
-            ['Zend\Expressive\Hal\ExpressiveUrlGenerator',                              'Mezzio\Hal\MezzioUrlGenerator'],
+            ['Zend\Expressive\Hal\LinkGenerator\ExpressiveUrlGenerator',                'Mezzio\Hal\LinkGenerator\MezzioUrlGenerator'],
             // phpcs:enable
 
             // Laminas
@@ -56,7 +56,9 @@ class AutoloaderTest extends TestCase
             // Apigility
             ['ZF\Apigility\BaseModule',        'Laminas\ApiTools\BaseModule'],
             ['ZF\BaseModule',                  'Laminas\ApiTools\BaseModule'],
-            ['ZF\Apigility\ApigilityProvider', 'Laminas\ApiTools\ApiToolsProvider'],
+            ['ZF\Apigility\Admin\Controller\ApigilityVersionController', 'Laminas\ApiTools\Admin\Controller\ApiToolsVersionController'],
+            ['ZF\Apigility\ApigilityModuleInterface', 'Laminas\ApiTools\ApiToolsModuleInterface', true],
+            ['ZF\Apigility\Provider\ApigilityProviderInterface', 'Laminas\ApiTools\Provider\ApiToolsProviderInterface', true],
         ];
     }
 
@@ -64,11 +66,14 @@ class AutoloaderTest extends TestCase
      * @dataProvider classProvider
      * @param string $legacy
      * @param string $actual
+     * @param null|bool $isInterface
      */
-    public function testLegacyClassIsAliasToLaminas($legacy, $actual)
+    public function testLegacyClassIsAliasToLaminas($legacy, $actual, $isInterface = false)
     {
-        self::assertTrue(class_exists($legacy));
-        self::assertSame($actual, get_class(new $legacy()));
+        self::assertTrue($isInterface ? interface_exists($legacy) : class_exists($legacy));
+        if (! $isInterface) {
+            self::assertSame($actual, get_class(new $legacy()));
+        }
     }
 
     public function testTypeHint()

--- a/test/TestAsset/Apigility/Other/ApiToolsClass.php
+++ b/test/TestAsset/Apigility/Other/ApiToolsClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Laminas\ApiTools\Other;
+
+class ApiToolsClass
+{
+}

--- a/test/TestAsset/Expressive/Other/MezzioClass.php
+++ b/test/TestAsset/Expressive/Other/MezzioClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Mezzio\Other;
+
+class MezzioClass
+{
+}

--- a/test/TestAsset/Laminas/Router/LaminasRouterClass.php
+++ b/test/TestAsset/Laminas/Router/LaminasRouterClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Laminas\Router;
+
+class LaminasRouterClass
+{
+}

--- a/test/classes.php
+++ b/test/classes.php
@@ -36,6 +36,10 @@ namespace Mezzio\Router {
     class LaminasRouter {}
 }
 
+namespace Mezzio\Hal {
+    class MezzioUrlGenerator {}
+}
+
 namespace Mezzio\Router\LaminasRouter {
     class RouterAdapter {}
 }
@@ -49,7 +53,7 @@ namespace Mezzio\ProblemDetails {
 }
 
 namespace Laminas {
-    class Expressive {}
+    class Mezzio {}
     class Main {}
     class Service {}
 }
@@ -85,6 +89,7 @@ namespace Laminas\Twitter {
 }
 
 namespace Laminas\ApiTools {
+    class ApiToolsProvider {}
     class BaseModule {}
 }
 

--- a/test/classes.php
+++ b/test/classes.php
@@ -36,7 +36,7 @@ namespace Mezzio\Router {
     class LaminasRouter {}
 }
 
-namespace Mezzio\Hal {
+namespace Mezzio\Hal\LinkGenerator {
     class MezzioUrlGenerator {}
 }
 
@@ -89,8 +89,16 @@ namespace Laminas\Twitter {
 }
 
 namespace Laminas\ApiTools {
-    class ApiToolsProvider {}
     class BaseModule {}
+    interface ApiToolsModuleInterface {}
+}
+
+namespace Laminas\ApiTools\Provider {
+    interface ApiToolsProviderInterface {}
+}
+
+namespace Laminas\ApiTools\Admin\Controller {
+    class ApiToolsVersionController {}
 }
 
 namespace Laminas\Xml {


### PR DESCRIPTION
There are three classes/interfaces prefixed with the term "Apigility":

- In zf-apigility-admin, ApigilityVersionController
- In zf-apigility, ApigilityModuleInterface
- In zf-apigility-provider, ApigilityProviderInterface

This patch updates the maps to map these to versions using the prefix "ApiTools".