### PR TITLE
Do not rewrite class names used for Auryn DI container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#39](https://github.com/laminas/laminas-zendframework-bridge/pull/39) fixes an issue when using the Auryn DI container. The class `Northwoods\Container\Zend\Config` was incorrectly being renamed to `Northwoods\Container\Laminas\Config` (which should not happen, as it is not a class under our control).
 
 ## 0.4.2 - 2019-12-16
 

--- a/config/replacements.php
+++ b/config/replacements.php
@@ -4,6 +4,7 @@ return [
     // NEVER REWRITE
     'zendframework/zendframework' => 'zendframework/zendframework',
     'Doctrine\\Zend' => 'Doctrine\\Zend',
+    'Northwoods\\Container\\Zend\\Config' => 'Northwoods\\Container\\Zend\\Config',
 
     // NAMESPACES
     // Zend Framework components


### PR DESCRIPTION
Specifically, `Northwoods\Container\Zend\Config`.

With this change, migrating to Laminas when using Auryn will work without errors.