### PR TITLE
Do not rewrite path to Doctrine toolbar template

### DIFF
--- a/config/replacements.php
+++ b/config/replacements.php
@@ -3,6 +3,7 @@
 return [
     // NEVER REWRITE
     'zendframework/zendframework' => 'zendframework/zendframework',
+    'zend-developer-tools/toolbar/doctrine' => 'zend-developer-tools/toolbar/doctrine',
 
     // NAMESPACES
     // Zend Framework components


### PR DESCRIPTION
DoctrineORMModule (and possibly others?) ship with the following template directory hierarchy:

```
view/
  zend-developer-tools/
    toolbar/
```

and all files in that tree have the prefix `doctrine-`.

This patch adds a rule to never rewrite such a path when it is found.  However, this also means that these rules _cannot be used to migrate Doctrine modules themselves_.

Fixes laminas/laminas-migration#24