### PR TITLE
Rewrite use_zend_loader to use_laminas_loader

### DIFF
--- a/config/replacements.php
+++ b/config/replacements.php
@@ -435,6 +435,7 @@ return [
 
     // CONFIG KEYS, SCRIPT NAMES, ETC
     // ZF components
+    'use_zend_loader' => 'use_laminas_loader', // zend-modulemanager
     'zend-config' => 'laminas-config',
     'zend-developer-tools/' => 'laminas-developer-tools/',
     'zend-tag-cloud' => 'laminas-tag-cloud',


### PR DESCRIPTION
The configuration key `use_zend_loader`, as provided and consumed by zend-modulemanager, was rewritten to `use_laminas_loader`. As such, we need to rewrite references to it during migrations.

Fixes laminas/laminas-migration#25