### PR TITLE
fix: migrate psr7bridge method calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
+- [#47](https://github.com/laminas/laminas-zendframework-bridge/pull/47) adds entries for rewriting the various `::*Zend()` methods exposed in the psr7bridge to `::*Laminas()` during migrations.
+
 - [#46](https://github.com/laminas/laminas-zendframework-bridge/pull/46) adds a rule to rewrite the config key `use_zend_loader` to `use_laminas_loader`.
 
 - [#45](https://github.com/laminas/laminas-zendframework-bridge/pull/45) adds a rule to exclude rewriting of view paths provided by the various Doctrine modules targeting the developer tools.

--- a/config/replacements.php
+++ b/config/replacements.php
@@ -435,6 +435,8 @@ return [
 
     // CONFIG KEYS, SCRIPT NAMES, ETC
     // ZF components
+    '::fromZend' => '::fromLaminas', // psr7bridge
+    '::toZend' => '::toLaminas', // psr7bridge
     'use_zend_loader' => 'use_laminas_loader', // zend-modulemanager
     'zend-config' => 'laminas-config',
     'zend-developer-tools/' => 'laminas-developer-tools/',


### PR DESCRIPTION
While we provided proxy methods for the original methods in the psr7bridge, when users migrate, they want their own calls to those methods to be migrated as well.

Fixes laminas/laminas-migration#27