### PR TITLE
Bugfix regarding unaliased services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#52](https://github.com/laminas/laminas-zendframework-bridge/pull/52) fixes a scenario whereby factory _values_ were not being rewritten during configuration post processing.
+
+- [#52](https://github.com/laminas/laminas-zendframework-bridge/pull/52) fixes an issue that occurs with the configuration post processor. Previously, when a service name used as a factory or invokable was encountered that referenced a legacy class, it would get rewritten. This would cause issues if the service was not exposed in the original legacy package, however, as there would now be no alias of the legacy service to the new one. This patch modifies the configuration post processor such that it now tests to see if a service name it will rename exists as an alias; if not, it also creates the alias.
 
 ## 1.0.1 - 2020-01-07
 

--- a/src/ConfigPostProcessor.php
+++ b/src/ConfigPostProcessor.php
@@ -239,8 +239,6 @@ class ConfigPostProcessor
         $aliases = isset($config['aliases']) ? $this->replaceDependencyAliases($config['aliases']) : [];
         $invokables = isset($config['invokables']) ? $this->replaceDependencyAliases($config['invokables']) : [];
 
-        $config = $this->replaceDependencyFactories($config);
-
         if ($aliases) {
             $config['aliases'] = $aliases;
         }
@@ -248,6 +246,8 @@ class ConfigPostProcessor
         if ($invokables) {
             $config['invokables'] = $invokables;
         }
+
+        $config = $this->replaceDependencyFactories($config);
 
         return $config;
     }

--- a/src/ConfigPostProcessor.php
+++ b/src/ConfigPostProcessor.php
@@ -10,7 +10,6 @@ namespace Laminas\ZendFrameworkBridge;
 
 use function array_flip;
 use function array_intersect_key;
-use function var_dump;
 
 class ConfigPostProcessor
 {
@@ -68,9 +67,7 @@ class ConfigPostProcessor
 
             // service- and pluginmanager handling
             function ($value) {
-                static $keysOfInterest;
-
-                $keysOfInterest = $keysOfInterest ?: ['aliases', 'invokables', 'factories'];
+                $keysOfInterest = ['aliases', 'invokables', 'factories'];
 
                 return is_array($value) && array_intersect_key(array_flip($keysOfInterest), $value) !== []
                     ? [$this, 'replaceDependencyConfiguration']
@@ -239,8 +236,8 @@ class ConfigPostProcessor
 
     private function replaceDependencyConfiguration(array $config)
     {
-        $aliases = $this->replaceDependencyAliases(isset($config['aliases']) ? $config['aliases'] : []);
-        $invokables = $this->replaceDependencyAliases(isset($config['invokables']) ? $config['invokables'] : []);
+        $aliases = isset($config['aliases']) ? $this->replaceDependencyAliases($config['aliases']) : [];
+        $invokables = isset($config['invokables']) ? $this->replaceDependencyAliases($config['invokables']) : [];
 
         $config = $this->replaceDependencyFactories($config);
 

--- a/src/ConfigPostProcessor.php
+++ b/src/ConfigPostProcessor.php
@@ -287,6 +287,7 @@ class ConfigPostProcessor
 
         foreach ($config['factories'] as $service => $factory) {
             $replacedService = $this->replacements->replace($service);
+            $factory         = is_string($factory) ? $this->replacements->replace($factory) : $factory;
             $config['factories'][$replacedService] = $factory;
 
             if ($replacedService === $service) {

--- a/src/ConfigPostProcessor.php
+++ b/src/ConfigPostProcessor.php
@@ -281,30 +281,24 @@ class ConfigPostProcessor
 
     private function replaceDependencyFactories(array $config)
     {
-        $factories = isset($config['factories']) ? $config['factories'] : [];
-        $aliases = isset($config['aliases']) ? $config['aliases'] : [];
+        if (empty($config['factories'])) {
+            return $config;
+        }
 
-        foreach ($factories as $service => $factory) {
+        foreach ($config['factories'] as $service => $factory) {
             $replacedService = $this->replacements->replace($service);
-            $factories[$replacedService] = $factory;
+            $config['factories'][$replacedService] = $factory;
 
             if ($replacedService === $service) {
                 continue;
             }
-            unset($factories[$service]);
-            if (isset($aliases[$service])) {
+
+            unset($config['factories'][$service]);
+            if (isset($config['aliases'][$service])) {
                 continue;
             }
 
-            $aliases[$service] = $replacedService;
-        }
-
-        if ($aliases !== []) {
-            $config['aliases'] = $aliases;
-        }
-
-        if ($factories !== []) {
-            $config['factories'] = $factories;
+            $config['aliases'][$service] = $replacedService;
         }
 
         return $config;

--- a/test/ConfigPostProcessorTest.php
+++ b/test/ConfigPostProcessorTest.php
@@ -25,6 +25,7 @@ class ConfigPostProcessorTest extends TestCase
         yield 'equivalent key merging' => ['MergeEquivalentKeys.php'];
         yield 'ignore router config' => ['RouterConfig.php'];
         yield 'process invokable config' => ['InvokableConfig.php'];
+        yield 'non aliased service config' => ['NonAliasedServiceConfiguration.php'];
     }
 
     /**

--- a/test/TestAsset/ConfigPostProcessor/ExpressiveSlimRouterConfig.php.out
+++ b/test/TestAsset/ConfigPostProcessor/ExpressiveSlimRouterConfig.php.out
@@ -6,5 +6,8 @@ return [
         'factories' => [
             'Mezzio\Router\RouterInterface' => Factory\SlimRouterFactory::class,
         ],
+        'aliases' => [
+            'Zend\Expressive\Router\RouterInterface' => 'Mezzio\Router\RouterInterface',
+        ],
     ],
 ];

--- a/test/TestAsset/ConfigPostProcessor/MwopNetAppConfig.php.out
+++ b/test/TestAsset/ConfigPostProcessor/MwopNetAppConfig.php.out
@@ -29,7 +29,6 @@ return [
             Csp::class                                   => Middleware\ContentSecurityPolicyMiddlewareFactory::class,
             CacheItemPoolInterface::class                => Factory\CachePoolFactory::class,
             EventDispatcherInterface::class              => Factory\EventDispatcherFactory::class,
-            'Laminas\Feed\Reader\Http\ClientInterface'   => Feed\HttpPlugClientFactory::class,
             Handler\ComicsPageHandler::class             => Handler\ComicsPageHandlerFactory::class,
             Handler\HomePageHandler::class               => Handler\HomePageHandlerFactory::class,
             Handler\ResumePageHandler::class             => Handler\PageHandlerFactory::class,
@@ -37,6 +36,7 @@ return [
             'mail.transport'                             => Factory\MailTransport::class,
             Middleware\RedirectAmpPagesMiddleware::class => Middleware\RedirectAmpPagesMiddlewareFactory::class,
             SessionCachePool::class                      => SessionCachePoolFactory::class,
+            'Laminas\Feed\Reader\Http\ClientInterface'   => Feed\HttpPlugClientFactory::class,
         ],
         'delegators' => [
             DisplayPostHandler::class => [
@@ -45,6 +45,9 @@ return [
             Engine::class => [
                 Factory\PlatesFunctionsDelegator::class,
             ],
+        ],
+        'aliases' => [
+            'Zend\Feed\Reader\Http\ClientInterface' => 'Laminas\Feed\Reader\Http\ClientInterface',
         ],
     ],
     'homepage' => [

--- a/test/TestAsset/ConfigPostProcessor/NonAliasedServiceConfiguration.php
+++ b/test/TestAsset/ConfigPostProcessor/NonAliasedServiceConfiguration.php
@@ -2,7 +2,7 @@
 return [
     'dependencies' => [
         'factories' => [
-            'Zend\Form\Factory' => 'Some\Vendor\Zend\Form\Factory',
+            'Zend\Form\Factory' => 'Some\Vendor\Zend\Form\ZendFormFactory',
             'Zend\Cache\Storage\StorageInterface' => 'Zend\ServiceManager\Factory\InvokableFactory',
         ],
         'aliases' => [

--- a/test/TestAsset/ConfigPostProcessor/NonAliasedServiceConfiguration.php
+++ b/test/TestAsset/ConfigPostProcessor/NonAliasedServiceConfiguration.php
@@ -4,5 +4,8 @@ return [
         'factories' => [
             'Zend\Form\Factory' => 'Some\Vendor\Zend\Form\Factory',
         ],
+        'aliases' => [
+            'foo' => 'Zend\Form\Factory',
+        ],
     ],
 ];

--- a/test/TestAsset/ConfigPostProcessor/NonAliasedServiceConfiguration.php
+++ b/test/TestAsset/ConfigPostProcessor/NonAliasedServiceConfiguration.php
@@ -3,9 +3,11 @@ return [
     'dependencies' => [
         'factories' => [
             'Zend\Form\Factory' => 'Some\Vendor\Zend\Form\Factory',
+            'Zend\Cache\Storage\StorageInterface' => 'Zend\ServiceManager\Factory\InvokableFactory',
         ],
         'aliases' => [
             'foo' => 'Zend\Form\Factory',
+            'Zend\Cache\Storage\StorageInterface' => 'Laminas\Cache\Storage\StorageInterface',
         ],
     ],
 ];

--- a/test/TestAsset/ConfigPostProcessor/NonAliasedServiceConfiguration.php
+++ b/test/TestAsset/ConfigPostProcessor/NonAliasedServiceConfiguration.php
@@ -1,0 +1,8 @@
+<?php
+return [
+    'dependencies' => [
+        'factories' => [
+            'Zend\Form\Factory' => 'Some\Vendor\Zend\Form\Factory',
+        ],
+    ],
+];

--- a/test/TestAsset/ConfigPostProcessor/NonAliasedServiceConfiguration.php.out
+++ b/test/TestAsset/ConfigPostProcessor/NonAliasedServiceConfiguration.php.out
@@ -2,7 +2,7 @@
 return [
     'dependencies' => [
         'factories' => [
-            'Laminas\Form\Factory' => 'Some\Vendor\Zend\Form\Factory',
+            'Laminas\Form\Factory' => 'Some\Vendor\Zend\Form\ZendFormFactory',
             'Laminas\Cache\Storage\StorageInterface' => 'Laminas\ServiceManager\Factory\InvokableFactory',
         ],
         'aliases' => [

--- a/test/TestAsset/ConfigPostProcessor/NonAliasedServiceConfiguration.php.out
+++ b/test/TestAsset/ConfigPostProcessor/NonAliasedServiceConfiguration.php.out
@@ -5,6 +5,7 @@ return [
             'Laminas\Form\Factory' => 'Some\Vendor\Zend\Form\Factory',
         ],
         'aliases' => [
+            'foo' => 'Laminas\Form\Factory',
             'Zend\Form\Factory' => 'Laminas\Form\Factory',
         ],
     ],

--- a/test/TestAsset/ConfigPostProcessor/NonAliasedServiceConfiguration.php.out
+++ b/test/TestAsset/ConfigPostProcessor/NonAliasedServiceConfiguration.php.out
@@ -1,0 +1,11 @@
+<?php
+return [
+    'dependencies' => [
+        'factories' => [
+            'Laminas\Form\Factory' => 'Some\Vendor\Zend\Form\Factory',
+        ],
+        'aliases' => [
+            'Zend\Form\Factory' => 'Laminas\Form\Factory',
+        ],
+    ],
+];

--- a/test/TestAsset/ConfigPostProcessor/NonAliasedServiceConfiguration.php.out
+++ b/test/TestAsset/ConfigPostProcessor/NonAliasedServiceConfiguration.php.out
@@ -3,9 +3,11 @@ return [
     'dependencies' => [
         'factories' => [
             'Laminas\Form\Factory' => 'Some\Vendor\Zend\Form\Factory',
+            'Laminas\Cache\Storage\StorageInterface' => 'Zend\ServiceManager\Factory\InvokableFactory',
         ],
         'aliases' => [
             'foo' => 'Laminas\Form\Factory',
+            'Zend\Cache\Storage\StorageInterface' => 'Laminas\Cache\Storage\StorageInterface',
             'Zend\Form\Factory' => 'Laminas\Form\Factory',
         ],
     ],

--- a/test/TestAsset/ConfigPostProcessor/NonAliasedServiceConfiguration.php.out
+++ b/test/TestAsset/ConfigPostProcessor/NonAliasedServiceConfiguration.php.out
@@ -3,7 +3,7 @@ return [
     'dependencies' => [
         'factories' => [
             'Laminas\Form\Factory' => 'Some\Vendor\Zend\Form\Factory',
-            'Laminas\Cache\Storage\StorageInterface' => 'Zend\ServiceManager\Factory\InvokableFactory',
+            'Laminas\Cache\Storage\StorageInterface' => 'Laminas\ServiceManager\Factory\InvokableFactory',
         ],
         'aliases' => [
             'foo' => 'Laminas\Form\Factory',


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

This is a fix for the related issue #51 

This change will add several, missing, aliases to the configuration after the post processor was executed. This will provide aliases for non-migrated packages which might be still required in an already migrated package.