### PR TITLE
Correctly rewrite "zf-apigility" configuration key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
+- [#57](https://github.com/laminas/laminas-zendframework-bridge/pull/57) fixes how references to the "zf-apigility" key are replaced. Previously, they were rewritten to "laminas-api-tools", but the correct replacement is "api-tools".
+
 - [#56](https://github.com/laminas/laminas-zendframework-bridge/pull/56) provides a mechanism to add additional maps with multiple levels of namespace separator escaping, in order to ensure that all various known permutations are matched. The escaping is applied to both the original and target, to ensure that rewrites conform to the original escaping.
 
 - [#56](https://github.com/laminas/laminas-zendframework-bridge/pull/56) makes changes to the replacement rules to ensure we do not replace references to "Zend" or "ZF" if they occur as subnamespaces OR as class names (formerly, we only enforced subnamespaces). Additional rules were provided for cases where one or both occur within our own packages.

--- a/config/replacements.php
+++ b/config/replacements.php
@@ -338,8 +338,8 @@ return [
     'zend-expressive-tooling' => 'mezzio-tooling',
 
     // Apigility-related
-    "'zf-apigility'" => "'laminas-api-tools'",
-    '"zf-apigility"' => '"laminas-api-tools"',
+    "'zf-apigility'" => "'api-tools'",
+    '"zf-apigility"' => '"api-tools"',
     'zf-apigility/' => 'api-tools/',
     'zf-apigility-admin' => 'api-tools-admin',
     'zf-content-negotiation' => 'api-tools-content-negotiation',

--- a/test/ReplacementsTest.php
+++ b/test/ReplacementsTest.php
@@ -94,6 +94,10 @@ class ReplacementsTest extends TestCase
             file_get_contents(__DIR__ . '/TestAsset/Replacements/phpstan-baseline.neon'),
             file_get_contents(__DIR__ . '/TestAsset/Replacements/phpstan-baseline.neon.out'),
         ];
+        yield 'api-tools config' => [
+            file_get_contents(__DIR__ . '/TestAsset/Replacements/module.config.php'),
+            file_get_contents(__DIR__ . '/TestAsset/Replacements/module.config.php.out'),
+        ];
     }
 
     /**

--- a/test/TestAsset/Replacements/module.config.php
+++ b/test/TestAsset/Replacements/module.config.php
@@ -1,0 +1,8 @@
+<?php
+
+return array(
+    'zf-apigility' => array(
+        'db-connected' => array(
+        ),
+    ),
+);

--- a/test/TestAsset/Replacements/module.config.php.out
+++ b/test/TestAsset/Replacements/module.config.php.out
@@ -1,0 +1,8 @@
+<?php
+
+return array(
+    'api-tools' => array(
+        'db-connected' => array(
+        ),
+    ),
+);


### PR DESCRIPTION
Should be "api-tools", not "laminas-api-tools".

Fixes laminas/laminas-migration#33