### PR TITLE
Ensure api-skeletons packages, classes, and configuration are not rewritten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
+- [#59](https://github.com/laminas/laminas-zendframework-bridge/pull/59) fixes the replacement rules such as to avoid replacing references to API Skeletons packages, classes, or configuration keys.
+
 - [#57](https://github.com/laminas/laminas-zendframework-bridge/pull/57) fixes how references to the "zf-apigility" key are replaced. Previously, they were rewritten to "laminas-api-tools", but the correct replacement is "api-tools".
 
 - [#56](https://github.com/laminas/laminas-zendframework-bridge/pull/56) provides a mechanism to add additional maps with multiple levels of namespace separator escaping, in order to ensure that all various known permutations are matched. The escaping is applied to both the original and target, to ensure that rewrites conform to the original escaping.

--- a/config/replacements.php
+++ b/config/replacements.php
@@ -361,4 +361,11 @@ return [
     'ZfApigilityDoctrineQueryCreateFilterManager' => 'LaminasApiToolsDoctrineQueryCreateFilterManager',
     'zf-apigility-doctrine' => 'api-tools-doctrine',
     'zf-development-mode' => 'laminas-development-mode',
+    'zf-doctrine-querybuilder' => 'api-tools-doctrine-querybuilder',
+
+    // 3rd party Apigility packages
+    'api-skeletons/zf-' => 'api-skeletons/zf-', // api-skeletons packages
+    'zf-oauth2-' => 'zf-oauth2-', // api-skeletons OAuth2-related packages
+    'ZF\\OAuth2\\Client' => 'ZF\\OAuth2\\Client', // api-skeletons/zf-oauth2-client
+    'ZF\\OAuth2\\Doctrine' => 'ZF\\OAuth2\\Doctrine', // api-skeletons/zf-oauth2-doctrine
 ];

--- a/test/ReplacementsTest.php
+++ b/test/ReplacementsTest.php
@@ -98,6 +98,18 @@ class ReplacementsTest extends TestCase
             file_get_contents(__DIR__ . '/TestAsset/Replacements/module.config.php'),
             file_get_contents(__DIR__ . '/TestAsset/Replacements/module.config.php.out'),
         ];
+        yield 'api-skeletons composer' => [
+            file_get_contents(__DIR__ . '/TestAsset/Replacements/api-skeletons-composer.json'),
+            file_get_contents(__DIR__ . '/TestAsset/Replacements/api-skeletons-composer.json.out'),
+        ];
+        yield 'api-skeletons OAuth2 Client' => [
+            file_get_contents(__DIR__ . '/TestAsset/Replacements/ZFOAuth2Client.php'),
+            file_get_contents(__DIR__ . '/TestAsset/Replacements/ZFOAuth2Client.php.out'),
+        ];
+        yield 'api-skeletons zf-oauth2-doctrine config' => [
+            file_get_contents(__DIR__ . '/TestAsset/Replacements/zf-oauth2-config.php'),
+            file_get_contents(__DIR__ . '/TestAsset/Replacements/zf-oauth2-config.php.out'),
+        ];
     }
 
     /**

--- a/test/TestAsset/Replacements/ZFOAuth2Client.php
+++ b/test/TestAsset/Replacements/ZFOAuth2Client.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace MyNamespace;
+
+use ZF\OAuth2\Client as OAuth2Client;
+
+class MyClient extends OAuth2Client
+{
+}

--- a/test/TestAsset/Replacements/ZFOAuth2Client.php.out
+++ b/test/TestAsset/Replacements/ZFOAuth2Client.php.out
@@ -1,0 +1,9 @@
+<?php
+
+namespace MyNamespace;
+
+use ZF\OAuth2\Client as OAuth2Client;
+
+class MyClient extends OAuth2Client
+{
+}

--- a/test/TestAsset/Replacements/api-skeletons-composer.json
+++ b/test/TestAsset/Replacements/api-skeletons-composer.json
@@ -1,0 +1,14 @@
+{
+    "require": {
+        "api-skeletons/zf-doctrine-criteria": "^1.0",
+        "api-skeletons/zf-doctrine-data-fixture": "^1.0",
+        "api-skeletons/zf-doctrine-graphql": "^1.0",
+        "api-skeletons/zf-doctrine-module-zend-hydrator": "^1.0",
+        "api-skeletons/zf-doctrine-repository": "^1.0",
+        "api-skeletons/zf-oauth2-client": "^1.0",
+        "api-skeletons/zf-oauth2-doctrine": "^1.0",
+        "api-skeletons/zf-oauth2-doctrine-console": "^1.0",
+        "api-skeletons/zf-oauth2-doctrine-identity": "^1.0",
+        "api-skeletons/zf-oauth2-doctrine-permissions-acl": "^1.0"
+    }
+}

--- a/test/TestAsset/Replacements/api-skeletons-composer.json.out
+++ b/test/TestAsset/Replacements/api-skeletons-composer.json.out
@@ -1,0 +1,14 @@
+{
+    "require": {
+        "api-skeletons/zf-doctrine-criteria": "^1.0",
+        "api-skeletons/zf-doctrine-data-fixture": "^1.0",
+        "api-skeletons/zf-doctrine-graphql": "^1.0",
+        "api-skeletons/zf-doctrine-module-zend-hydrator": "^1.0",
+        "api-skeletons/zf-doctrine-repository": "^1.0",
+        "api-skeletons/zf-oauth2-client": "^1.0",
+        "api-skeletons/zf-oauth2-doctrine": "^1.0",
+        "api-skeletons/zf-oauth2-doctrine-console": "^1.0",
+        "api-skeletons/zf-oauth2-doctrine-identity": "^1.0",
+        "api-skeletons/zf-oauth2-doctrine-permissions-acl": "^1.0"
+    }
+}

--- a/test/TestAsset/Replacements/zf-oauth2-config.php
+++ b/test/TestAsset/Replacements/zf-oauth2-config.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'zf-oauth2-doctrine' => [
+    ],
+    'zf-oauth2-doctrine-permissions-acl' => [
+    ],
+    'zf-doctrine-querybuilder' => [
+    ],
+];

--- a/test/TestAsset/Replacements/zf-oauth2-config.php.out
+++ b/test/TestAsset/Replacements/zf-oauth2-config.php.out
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'zf-oauth2-doctrine' => [
+    ],
+    'zf-oauth2-doctrine-permissions-acl' => [
+    ],
+    'api-tools-doctrine-querybuilder' => [
+    ],
+];


### PR DESCRIPTION
Adds rules to ensure that the various API Skeletons packages, classes, and configuration keys do not get rewritten.

Fixes laminas/laminas-migration#41