### PR TITLE
Added missing handling for some dependency configuration keys

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd">
-    <rule ref="PSR12"/>
+    <rule ref="PSR12">
+        <exclude name="PSR12.Properties.ConstantVisibility.NotFound"/>
+    </rule>
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 
     <arg value="p"/>

--- a/src/ConfigPostProcessor.php
+++ b/src/ConfigPostProcessor.php
@@ -286,6 +286,10 @@ class ConfigPostProcessor
     private function replaceDependencyAliases(array $aliases)
     {
         foreach ($aliases as $alias => $target) {
+            if (! is_string($alias) || ! is_string($target)) {
+                continue;
+            }
+
             $newTarget = $this->replacements->replace($target);
             $newAlias  = $this->replacements->replace($alias);
 

--- a/src/ConfigPostProcessor.php
+++ b/src/ConfigPostProcessor.php
@@ -8,6 +8,7 @@
 
 namespace Laminas\ZendFrameworkBridge;
 
+use function array_flip;
 use function array_intersect_key;
 use function array_key_exists;
 use function array_pop;
@@ -75,19 +76,11 @@ class ConfigPostProcessor
 
             // service- and pluginmanager handling
             function ($value) {
-                if (! is_array($value)) {
-                    return null;
-                }
+                $keysOfInterest = ['aliases', 'factories', 'invokables'];
 
-                $keysOfInterest = [
-                    'aliases' => true,
-                    'factories' => true,
-                    'invokables' => true,
-                ];
-
-                return array_intersect_key($keysOfInterest, $value) !== []
+                return is_array($value) && array_intersect_key(array_flip($keysOfInterest), $value) !== []
                     ? [$this, 'replaceDependencyConfiguration']
-                    : [$this, '__invoke'];
+                    : null;
             },
 
             // Array values

--- a/src/ConfigPostProcessor.php
+++ b/src/ConfigPostProcessor.php
@@ -76,7 +76,7 @@ class ConfigPostProcessor
 
             // service- and pluginmanager handling
             function ($value) {
-                $keysOfInterest = ['aliases', 'factories', 'invokables'];
+                $keysOfInterest = ['aliases', 'invokables', 'factories'];
 
                 return is_array($value) && array_intersect_key(array_flip($keysOfInterest), $value) !== []
                     ? [$this, 'replaceDependencyConfiguration']

--- a/src/ConfigPostProcessor.php
+++ b/src/ConfigPostProcessor.php
@@ -8,7 +8,6 @@
 
 namespace Laminas\ZendFrameworkBridge;
 
-use function array_flip;
 use function array_intersect_key;
 use function array_key_exists;
 use function array_pop;
@@ -22,8 +21,13 @@ use function is_string;
 
 class ConfigPostProcessor
 {
-    /** @var array<string> */
-    private static $SERVICE_MANAGER_KEYS_OF_INTEREST = ['aliases', 'invokables', 'factories', 'services'];
+    /** @internal */
+    const SERVICE_MANAGER_KEYS_OF_INTEREST = [
+        'aliases'    => true,
+        'factories'  => true,
+        'invokables' => true,
+        'services'   => true,
+    ];
 
     /** @var array String keys => string values */
     private $exactReplacements = [
@@ -79,9 +83,7 @@ class ConfigPostProcessor
 
             // service- and pluginmanager handling
             function ($value) {
-                $keysOfInterest = self::$SERVICE_MANAGER_KEYS_OF_INTEREST;
-
-                return is_array($value) && array_intersect_key(array_flip($keysOfInterest), $value) !== []
+                return is_array($value) && array_intersect_key(self::SERVICE_MANAGER_KEYS_OF_INTEREST, $value) !== []
                     ? [$this, 'replaceDependencyConfiguration']
                     : null;
             },
@@ -257,8 +259,9 @@ class ConfigPostProcessor
         $config = $this->replaceDependencyFactories($config);
         $config = $this->replaceDependencyServices($config);
 
+        $keys = self::SERVICE_MANAGER_KEYS_OF_INTEREST;
         foreach ($config as $key => $data) {
-            if (in_array($key, self::$SERVICE_MANAGER_KEYS_OF_INTEREST, true)) {
+            if (isset($keys[$key])) {
                 continue;
             }
 

--- a/src/ConfigPostProcessor.php
+++ b/src/ConfigPostProcessor.php
@@ -358,6 +358,9 @@ class ConfigPostProcessor
         }
 
         foreach ($config['invokables'] as $alias => $target) {
+            if (!is_string($alias)) {
+                continue;
+            }
             $newTarget = $this->replacements->replace($target);
             $newAlias  = $this->replacements->replace($alias);
 
@@ -396,6 +399,10 @@ class ConfigPostProcessor
         }
 
         foreach ($config['factories'] as $service => $factory) {
+            if (!is_string($service)) {
+                continue;
+            }
+
             $replacedService = $this->replacements->replace($service);
             $factory         = is_string($factory) ? $this->replacements->replace($factory) : $factory;
             $config['factories'][$replacedService] = $factory;

--- a/src/ConfigPostProcessor.php
+++ b/src/ConfigPostProcessor.php
@@ -23,7 +23,7 @@ use function is_string;
 class ConfigPostProcessor
 {
     /** @var array<string> */
-    const SERVICE_MANAGER_KEYS_OF_INTEREST = ['aliases', 'invokables', 'factories', 'services'];
+    private static $SERVICE_MANAGER_KEYS_OF_INTEREST = ['aliases', 'invokables', 'factories', 'services'];
 
     /** @var array String keys => string values */
     private $exactReplacements = [
@@ -79,7 +79,7 @@ class ConfigPostProcessor
 
             // service- and pluginmanager handling
             function ($value) {
-                $keysOfInterest = self::SERVICE_MANAGER_KEYS_OF_INTEREST;
+                $keysOfInterest = self::$SERVICE_MANAGER_KEYS_OF_INTEREST;
 
                 return is_array($value) && array_intersect_key(array_flip($keysOfInterest), $value) !== []
                     ? [$this, 'replaceDependencyConfiguration']
@@ -258,11 +258,11 @@ class ConfigPostProcessor
         $config = $this->replaceDependencyServices($config);
 
         foreach ($config as $key => $data) {
-            if (in_array($key, self::SERVICE_MANAGER_KEYS_OF_INTEREST, true)) {
+            if (in_array($key, self::$SERVICE_MANAGER_KEYS_OF_INTEREST, true)) {
                 continue;
             }
 
-            $config[$key] = is_array($data) ? $this->__invoke($data, [$key]):  $data;
+            $config[$key] = is_array($data) ? $this->__invoke($data, [$key]) :  $data;
         }
 
         return $config;

--- a/src/ConfigPostProcessor.php
+++ b/src/ConfigPostProcessor.php
@@ -22,6 +22,9 @@ use function is_string;
 
 class ConfigPostProcessor
 {
+    /** @var array<string> */
+    const SERVICE_MANAGER_KEYS_OF_INTEREST = ['aliases', 'invokables', 'factories'];
+
     /** @var array String keys => string values */
     private $exactReplacements = [
         'zend-expressive' => 'mezzio',
@@ -76,7 +79,7 @@ class ConfigPostProcessor
 
             // service- and pluginmanager handling
             function ($value) {
-                $keysOfInterest = ['aliases', 'invokables', 'factories'];
+                $keysOfInterest = self::SERVICE_MANAGER_KEYS_OF_INTEREST;
 
                 return is_array($value) && array_intersect_key(array_flip($keysOfInterest), $value) !== []
                     ? [$this, 'replaceDependencyConfiguration']
@@ -254,7 +257,7 @@ class ConfigPostProcessor
         $config = $this->replaceDependencyFactories($config);
 
         foreach ($config as $key => $data) {
-            if (in_array($key, ['aliases', 'invokables', 'factories'], true)) {
+            if (in_array($key, self::SERVICE_MANAGER_KEYS_OF_INTEREST, true)) {
                 continue;
             }
 

--- a/src/ConfigPostProcessor.php
+++ b/src/ConfigPostProcessor.php
@@ -323,7 +323,7 @@ class ConfigPostProcessor
      */
     private function replaceDependencyInvokables(array $config)
     {
-        if (empty($config['invokables'])) {
+        if (empty($config['invokables']) || ! is_array($config['invokables'])) {
             return $config;
         }
 
@@ -365,7 +365,7 @@ class ConfigPostProcessor
 
     private function replaceDependencyFactories(array $config)
     {
-        if (empty($config['factories'])) {
+        if (empty($config['factories']) || ! is_array($config['factories'])) {
             return $config;
         }
 
@@ -395,7 +395,7 @@ class ConfigPostProcessor
 
     private function replaceDependencyServices(array $config)
     {
-        if (empty($config['services'])) {
+        if (empty($config['services']) || ! is_array($config['services'])) {
             return $config;
         }
 

--- a/src/ConfigPostProcessor.php
+++ b/src/ConfigPostProcessor.php
@@ -401,11 +401,14 @@ class ConfigPostProcessor
 
         foreach ($config['services'] as $service => $serviceInstance) {
             $replacedService = $this->replacements->replace($service);
+            $serviceInstance = is_array($serviceInstance) ? $this->__invoke($serviceInstance) : $serviceInstance;
+
+            $config['services'][$replacedService] = $serviceInstance;
 
             if ($service === $replacedService) {
                 continue;
             }
-            $config['services'][$replacedService] = $serviceInstance;
+
             unset($config['services'][$service]);
 
             if (isset($config['aliases'][$service])) {

--- a/src/ConfigPostProcessor.php
+++ b/src/ConfigPostProcessor.php
@@ -330,9 +330,10 @@ class ConfigPostProcessor
         }
 
         foreach ($config['invokables'] as $alias => $target) {
-            if (!is_string($alias)) {
+            if (! is_string($alias)) {
                 continue;
             }
+
             $newTarget = $this->replacements->replace($target);
             $newAlias  = $this->replacements->replace($alias);
 
@@ -371,7 +372,7 @@ class ConfigPostProcessor
         }
 
         foreach ($config['factories'] as $service => $factory) {
-            if (!is_string($service)) {
+            if (! is_string($service)) {
                 continue;
             }
 

--- a/src/ConfigPostProcessor.php
+++ b/src/ConfigPostProcessor.php
@@ -75,21 +75,19 @@ class ConfigPostProcessor
 
             // service- and pluginmanager handling
             function ($value) {
+                if (! is_array($value)) {
+                    return null;
+                }
+
                 $keysOfInterest = [
-                    'abstract_factories' => true,
                     'aliases' => true,
-                    'delegators' => true,
                     'factories' => true,
-                    'initializers' => true,
                     'invokables' => true,
-                    'lazy_services' => true,
-                    'services' => true,
-                    'shared' => true,
                 ];
 
                 return is_array($value) && array_intersect_key($keysOfInterest, $value) !== []
                     ? [$this, 'replaceDependencyConfiguration']
-                    : null;
+                    : [$this, '__invoke'];
             },
 
             // Array values

--- a/src/ConfigPostProcessor.php
+++ b/src/ConfigPostProcessor.php
@@ -400,6 +400,10 @@ class ConfigPostProcessor
         }
 
         foreach ($config['services'] as $service => $serviceInstance) {
+            if (! is_string($service)) {
+                continue;
+            }
+
             $replacedService = $this->replacements->replace($service);
             $serviceInstance = is_array($serviceInstance) ? $this->__invoke($serviceInstance) : $serviceInstance;
 

--- a/src/ConfigPostProcessor.php
+++ b/src/ConfigPostProcessor.php
@@ -258,7 +258,7 @@ class ConfigPostProcessor
                 continue;
             }
 
-            $config[$key] = $this->__invoke($config[$key], [$key]);
+            $config[$key] = is_array($data) ? $this->__invoke($data, [$key]):  $data;
         }
 
         return $config;

--- a/src/ConfigPostProcessor.php
+++ b/src/ConfigPostProcessor.php
@@ -85,7 +85,7 @@ class ConfigPostProcessor
                     'invokables' => true,
                 ];
 
-                return is_array($value) && array_intersect_key($keysOfInterest, $value) !== []
+                return array_intersect_key($keysOfInterest, $value) !== []
                     ? [$this, 'replaceDependencyConfiguration']
                     : [$this, '__invoke'];
             },

--- a/src/ConfigPostProcessor.php
+++ b/src/ConfigPostProcessor.php
@@ -250,7 +250,9 @@ class ConfigPostProcessor
 
     private function replaceDependencyConfiguration(array $config)
     {
-        $aliases = isset($config['aliases']) ? $this->replaceDependencyAliases($config['aliases']) : [];
+        $aliases = isset($config['aliases']) && is_array($config['aliases']) ?
+            $this->replaceDependencyAliases($config['aliases']) : [];
+
         if ($aliases) {
             $config['aliases'] = $aliases;
         }

--- a/src/ConfigPostProcessor.php
+++ b/src/ConfigPostProcessor.php
@@ -250,8 +250,9 @@ class ConfigPostProcessor
 
     private function replaceDependencyConfiguration(array $config)
     {
-        $aliases = isset($config['aliases']) && is_array($config['aliases']) ?
-            $this->replaceDependencyAliases($config['aliases']) : [];
+        $aliases = isset($config['aliases']) && is_array($config['aliases'])
+            ? $this->replaceDependencyAliases($config['aliases'])
+            : [];
 
         if ($aliases) {
             $config['aliases'] = $aliases;

--- a/test/ConfigPostProcessorTest.php
+++ b/test/ConfigPostProcessorTest.php
@@ -32,6 +32,7 @@ class ConfigPostProcessorTest extends TestCase
         yield 'abstract factories' => ['AbstractFactories.php'];
         yield 'lazy services' => ['LazyServices.php'];
         yield 'service manager configuration' => ['FullServiceManagerConfiguration.php'];
+        yield 'invalid service manager configuration' => ['InvalidServiceManagerConfiguration.php'];
     }
 
     /**

--- a/test/ConfigPostProcessorTest.php
+++ b/test/ConfigPostProcessorTest.php
@@ -11,6 +11,7 @@ namespace LaminasTest\ZendFrameworkBridge;
 use Laminas\ZendFrameworkBridge\ConfigPostProcessor;
 use PHPUnit\Framework\TestCase;
 
+use stdClass;
 use function sprintf;
 
 class ConfigPostProcessorTest extends TestCase
@@ -116,6 +117,27 @@ class ConfigPostProcessorTest extends TestCase
                 'dependencies' => [
                     'lazy_services' => [
                         'class_map' => 'non-array',
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'non string values in alias key/value pairs' => [
+            [
+                'dependencies' => [
+                    'aliases' => [
+                        'foo',
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'non string value for mapped alias' => [
+            [
+                'dependencies' => [
+                    'aliases' => [
+                        'foo' => 0,
+                        'bar' => new stdClass(),
                     ],
                 ],
             ],

--- a/test/ConfigPostProcessorTest.php
+++ b/test/ConfigPostProcessorTest.php
@@ -74,4 +74,51 @@ class ConfigPostProcessorTest extends TestCase
         $processor = new ConfigPostProcessor();
         self::assertSame($expected, $processor($config));
     }
+
+    /**
+     * @param array<string,array<string,mixed>> $config
+     *
+     * @dataProvider invalidServiceManagerConfiguration
+     */
+    public function testWillSkipInvalidConfigurations($config)
+    {
+        $processor = new ConfigPostProcessor();
+        self::assertSame($config, $processor($config));
+    }
+
+    public function invalidServiceManagerConfiguration()
+    {
+        yield 'non array values in dependency config' => [
+            [
+                'dependencies' => [
+                    'services' => 'non-array',
+                    'aliases' => 'non-array',
+                    'factories' => 'non-array',
+                    'delegators' => 'non-array',
+                    'invokables' => 'non-array',
+                    'abstract_factories' => 'non-array',
+                ],
+            ],
+        ];
+
+        yield 'non array values in dependency delegators config' => [
+            [
+                'dependencies' => [
+                    'delegators' => [
+                        'class' => 'non-array',
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'non array values in lazy_services.class_map config' => [
+            [
+                'dependencies' => [
+                    'lazy_services' => [
+                        'class_map' => 'non-array',
+                    ],
+                ],
+            ],
+        ];
+    }
 }

--- a/test/ConfigPostProcessorTest.php
+++ b/test/ConfigPostProcessorTest.php
@@ -29,6 +29,8 @@ class ConfigPostProcessorTest extends TestCase
         yield 'process invokable config' => ['InvokableConfig.php'];
         yield 'non aliased service config' => ['NonAliasedServiceConfiguration.php'];
         yield 'config delegators' => ['Delegators.php'];
+        yield 'abstract factories' => ['AbstractFactories.php'];
+        yield 'lazy services' => ['LazyServices.php'];
     }
 
     /**

--- a/test/ConfigPostProcessorTest.php
+++ b/test/ConfigPostProcessorTest.php
@@ -50,4 +50,28 @@ class ConfigPostProcessorTest extends TestCase
 
         $this->assertSame($expected, $processor($config));
     }
+
+    public function testServiceManagerServiceInstancesCanBeHandled()
+    {
+        $instance = new \stdClass();
+        $config = [
+            'dependencies' => [
+                'services' => [
+                    'Zend\Cache\Class' => $instance,
+                ],
+            ],
+        ];
+        $expected = [
+            'dependencies' => [
+                'services' => [
+                    'Laminas\Cache\Class' => $instance,
+                ],
+                'aliases' => [
+                    'Zend\Cache\Class' => 'Laminas\Cache\Class',
+                ],
+            ],
+        ];
+        $processor = new ConfigPostProcessor();
+        self::assertSame($expected, $processor($config));
+    }
 }

--- a/test/ConfigPostProcessorTest.php
+++ b/test/ConfigPostProcessorTest.php
@@ -10,8 +10,8 @@ namespace LaminasTest\ZendFrameworkBridge;
 
 use Laminas\ZendFrameworkBridge\ConfigPostProcessor;
 use PHPUnit\Framework\TestCase;
-
 use stdClass;
+
 use function sprintf;
 
 class ConfigPostProcessorTest extends TestCase
@@ -54,25 +54,27 @@ class ConfigPostProcessorTest extends TestCase
 
     public function testServiceManagerServiceInstancesCanBeHandled()
     {
-        $instance = new \stdClass();
+        $instance = new stdClass();
         $config = [
             'dependencies' => [
                 'services' => [
-                    'Zend\Cache\Class' => $instance,
+                    'Zend\Cache\MyClass' => $instance,
                 ],
             ],
         ];
         $expected = [
             'dependencies' => [
                 'services' => [
-                    'Laminas\Cache\Class' => $instance,
+                    'Laminas\Cache\MyClass' => $instance,
                 ],
                 'aliases' => [
-                    'Zend\Cache\Class' => 'Laminas\Cache\Class',
+                    'Zend\Cache\MyClass' => 'Laminas\Cache\MyClass',
                 ],
             ],
         ];
+
         $processor = new ConfigPostProcessor();
+
         self::assertSame($expected, $processor($config));
     }
 

--- a/test/ConfigPostProcessorTest.php
+++ b/test/ConfigPostProcessorTest.php
@@ -31,6 +31,7 @@ class ConfigPostProcessorTest extends TestCase
         yield 'config delegators' => ['Delegators.php'];
         yield 'abstract factories' => ['AbstractFactories.php'];
         yield 'lazy services' => ['LazyServices.php'];
+        yield 'service manager configuration' => ['FullServiceManagerConfiguration.php'];
     }
 
     /**

--- a/test/TestAsset/ConfigPostProcessor/AbstractFactories.php
+++ b/test/TestAsset/ConfigPostProcessor/AbstractFactories.php
@@ -1,0 +1,24 @@
+<?php
+
+use Zend\ServiceManager\AbstractFactory\ConfigAbstractFactory;
+use Zend\ServiceManager\Factory\InvokableFactory;
+
+return [
+    'service_manager' => [
+        'factories' => [
+            'MyService' => InvokableFactory::class,
+        ],
+        'abstract_factories' => [
+            ConfigAbstractFactory::class,
+        ],
+    ],
+
+    'dependencies' => [
+        'factories' => [
+            'MyService' => InvokableFactory::class,
+        ],
+        'abstract_factories' => [
+            ConfigAbstractFactory::class,
+        ],
+    ],
+];

--- a/test/TestAsset/ConfigPostProcessor/AbstractFactories.php
+++ b/test/TestAsset/ConfigPostProcessor/AbstractFactories.php
@@ -10,6 +10,7 @@ return [
         ],
         'abstract_factories' => [
             ConfigAbstractFactory::class,
+            'Zend\ServiceManager\AbstractFactory\ConfigAbstractFactory',
         ],
     ],
 
@@ -19,6 +20,7 @@ return [
         ],
         'abstract_factories' => [
             ConfigAbstractFactory::class,
+            'Zend\ServiceManager\AbstractFactory\ConfigAbstractFactory',
         ],
     ],
 ];

--- a/test/TestAsset/ConfigPostProcessor/AbstractFactories.php.out
+++ b/test/TestAsset/ConfigPostProcessor/AbstractFactories.php.out
@@ -10,6 +10,7 @@ return [
         ],
         'abstract_factories' => [
             ConfigAbstractFactory::class,
+            'Laminas\ServiceManager\AbstractFactory\ConfigAbstractFactory',
         ],
     ],
 
@@ -19,6 +20,7 @@ return [
         ],
         'abstract_factories' => [
             ConfigAbstractFactory::class,
+            'Laminas\ServiceManager\AbstractFactory\ConfigAbstractFactory',
         ],
     ],
 ];

--- a/test/TestAsset/ConfigPostProcessor/AbstractFactories.php.out
+++ b/test/TestAsset/ConfigPostProcessor/AbstractFactories.php.out
@@ -1,0 +1,24 @@
+<?php
+
+use Laminas\ServiceManager\AbstractFactory\ConfigAbstractFactory;
+use Laminas\ServiceManager\Factory\InvokableFactory;
+
+return [
+    'service_manager' => [
+        'factories' => [
+            'MyService' => InvokableFactory::class,
+        ],
+        'abstract_factories' => [
+            ConfigAbstractFactory::class,
+        ],
+    ],
+
+    'dependencies' => [
+        'factories' => [
+            'MyService' => InvokableFactory::class,
+        ],
+        'abstract_factories' => [
+            ConfigAbstractFactory::class,
+        ],
+    ],
+];

--- a/test/TestAsset/ConfigPostProcessor/FullServiceManagerConfiguration.php
+++ b/test/TestAsset/ConfigPostProcessor/FullServiceManagerConfiguration.php
@@ -1,0 +1,42 @@
+<?php
+
+return [
+    'service_manager' => [
+        'abstract_factories' => [
+            'Zend\ServiceManager\AbstractFactory\ConfigAbstractFactory',
+        ],
+        'aliases' => [
+            'Zend\Cache\Storage\StorageInterface' => 'Zend\Cache\Storage\Adapter\Redis',
+        ],
+        'delegators' => [
+            'Zend\Cache\Storage\Adapter\Redis' => [
+                'Zend\ServiceManager\Proxy\LazyServiceFactory',
+            ],
+        ],
+        'factories' => [
+            'Zend\Form\Factory' => 'Some\Vendor\Zend\Form\ZendFormFactory',
+            'MyService' => 'Zend\ServiceManager\Factory\InvokableFactory',
+        ],
+        'initializers' => [
+            // Just for testing purposes, this initializer does not exist
+            'Zend\Form\FactoryInitializer',
+        ],
+        'invokables' => [
+            'Zend\Expressive\Router\RouterInterface' => 'MyService',
+        ],
+        'lazy_services' => [
+            'class_map' => [
+                'Zend\Cache\Storage\Adapter\Redis' => 'Zend\Cache\Storage\Adapter\Redis',
+            ],
+        ],
+        'services' => [
+            // NOTE: this is an invalid configuration, you have to provide service instances in this array.
+            // For testing purposes, we have to change this to a string we can use to verify that the value
+            // is not touched at all. Using instances would lead to
+            'Zend\Cache\Storage\Adapter\Redis' => 'Zend\Cache\Storage\Adapter\Redis',
+        ],
+        'shared' => [
+            'Zend\Form\Factory' => false,
+        ],
+    ],
+];

--- a/test/TestAsset/ConfigPostProcessor/FullServiceManagerConfiguration.php
+++ b/test/TestAsset/ConfigPostProcessor/FullServiceManagerConfiguration.php
@@ -37,6 +37,10 @@ return [
                     'timeout' => 0,
                 ],
             ],
+            'preferred-cache-storage' => [
+                'name' => 'Zend\Cache\Storage\Adapter\Redis',
+                'options' => 'Zend\Cache\Storage\Adapter\RedisOptions',
+            ],
         ],
         'shared' => [
             'Zend\Form\Factory' => false,

--- a/test/TestAsset/ConfigPostProcessor/FullServiceManagerConfiguration.php
+++ b/test/TestAsset/ConfigPostProcessor/FullServiceManagerConfiguration.php
@@ -38,5 +38,6 @@ return [
         'shared' => [
             'Zend\Form\Factory' => false,
         ],
+        'sharedByDefault' => false,
     ],
 ];

--- a/test/TestAsset/ConfigPostProcessor/FullServiceManagerConfiguration.php
+++ b/test/TestAsset/ConfigPostProcessor/FullServiceManagerConfiguration.php
@@ -30,10 +30,13 @@ return [
             ],
         ],
         'services' => [
-            // NOTE: this is an invalid configuration, you have to provide service instances in this array.
-            // For testing purposes, we have to change this to a string we can use to verify that the value
-            // is not touched at all. Using instances would lead to
-            'Zend\Cache\Storage\Adapter\Redis' => 'Zend\Cache\Storage\Adapter\Redis',
+            'Zend\Cache\Storage\Adapter\RedisOptions' => [
+                'server' => [
+                    'host' => 'localhost',
+                    'port' => 6379,
+                    'timeout' => 0,
+                ],
+            ],
         ],
         'shared' => [
             'Zend\Form\Factory' => false,

--- a/test/TestAsset/ConfigPostProcessor/FullServiceManagerConfiguration.php.out
+++ b/test/TestAsset/ConfigPostProcessor/FullServiceManagerConfiguration.php.out
@@ -1,0 +1,43 @@
+<?php
+
+return [
+    'service_manager' => [
+        'abstract_factories' => [
+            'Laminas\ServiceManager\AbstractFactory\ConfigAbstractFactory',
+        ],
+        'aliases' => [
+            'Zend\Cache\Storage\StorageInterface' => 'Laminas\Cache\Storage\StorageInterface',
+            'Laminas\Cache\Storage\StorageInterface' => 'Laminas\Cache\Storage\Adapter\Redis',
+            'Zend\Expressive\Router\RouterInterface' => 'Mezzio\Router\RouterInterface',
+            'Zend\Form\Factory' => 'Laminas\Form\Factory',
+
+        ],
+        'delegators' => [
+            'Laminas\Cache\Storage\Adapter\Redis' => [
+                'Laminas\ServiceManager\Proxy\LazyServiceFactory',
+            ],
+        ],
+        'factories' => [
+            'MyService' => 'Laminas\ServiceManager\Factory\InvokableFactory',
+            'Laminas\Form\Factory' => 'Some\Vendor\Zend\Form\ZendFormFactory',
+        ],
+        'initializers' => [
+            // Just for testing purposes, this initializer does not exist
+            'Laminas\Form\FactoryInitializer',
+        ],
+        'invokables' => [
+            'Mezzio\Router\RouterInterface' => 'MyService',
+        ],
+        'lazy_services' => [
+            'class_map' => [
+                'Laminas\Cache\Storage\Adapter\Redis' => 'Laminas\Cache\Storage\Adapter\Redis',
+            ],
+        ],
+        'services' => [
+            'Laminas\Cache\Storage\Adapter\Redis' => 'Zend\Cache\Storage\Adapter\Redis',
+        ],
+        'shared' => [
+            'Laminas\Form\Factory' => false,
+        ],
+    ],
+];

--- a/test/TestAsset/ConfigPostProcessor/FullServiceManagerConfiguration.php.out
+++ b/test/TestAsset/ConfigPostProcessor/FullServiceManagerConfiguration.php.out
@@ -34,7 +34,7 @@ return [
             ],
         ],
         'services' => [
-            'Laminas\Cache\Storage\Adapter\Redis' => 'Zend\Cache\Storage\Adapter\Redis',
+            'Laminas\Cache\Storage\Adapter\Redis' => 'Laminas\Cache\Storage\Adapter\Redis',
         ],
         'shared' => [
             'Laminas\Form\Factory' => false,

--- a/test/TestAsset/ConfigPostProcessor/FullServiceManagerConfiguration.php.out
+++ b/test/TestAsset/ConfigPostProcessor/FullServiceManagerConfiguration.php.out
@@ -34,6 +34,10 @@ return [
             ],
         ],
         'services' => [
+            'preferred-cache-storage' => [
+                'name' => 'Laminas\Cache\Storage\Adapter\Redis',
+                'options' => 'Laminas\Cache\Storage\Adapter\RedisOptions',
+            ],
             'Laminas\Cache\Storage\Adapter\RedisOptions' => [
                 'server' => [
                     'host' => 'localhost',

--- a/test/TestAsset/ConfigPostProcessor/FullServiceManagerConfiguration.php.out
+++ b/test/TestAsset/ConfigPostProcessor/FullServiceManagerConfiguration.php.out
@@ -34,7 +34,7 @@ return [
             ],
         ],
         'services' => [
-            'Laminas\Cache\Storage\Adapter\Redis' => 'Laminas\Cache\Storage\Adapter\Redis',
+            'Laminas\Cache\Storage\Adapter\Redis' => 'Zend\Cache\Storage\Adapter\Redis',
         ],
         'shared' => [
             'Laminas\Form\Factory' => false,

--- a/test/TestAsset/ConfigPostProcessor/FullServiceManagerConfiguration.php.out
+++ b/test/TestAsset/ConfigPostProcessor/FullServiceManagerConfiguration.php.out
@@ -39,5 +39,6 @@ return [
         'shared' => [
             'Laminas\Form\Factory' => false,
         ],
+        'sharedByDefault' => false,
     ],
 ];

--- a/test/TestAsset/ConfigPostProcessor/FullServiceManagerConfiguration.php.out
+++ b/test/TestAsset/ConfigPostProcessor/FullServiceManagerConfiguration.php.out
@@ -10,7 +10,7 @@ return [
             'Laminas\Cache\Storage\StorageInterface' => 'Laminas\Cache\Storage\Adapter\Redis',
             'Zend\Expressive\Router\RouterInterface' => 'Mezzio\Router\RouterInterface',
             'Zend\Form\Factory' => 'Laminas\Form\Factory',
-            'Zend\Cache\Storage\Adapter\Redis' => 'Laminas\Cache\Storage\Adapter\Redis',
+            'Zend\Cache\Storage\Adapter\RedisOptions' => 'Laminas\Cache\Storage\Adapter\RedisOptions',
         ],
         'delegators' => [
             'Laminas\Cache\Storage\Adapter\Redis' => [
@@ -34,7 +34,13 @@ return [
             ],
         ],
         'services' => [
-            'Laminas\Cache\Storage\Adapter\Redis' => 'Zend\Cache\Storage\Adapter\Redis',
+            'Laminas\Cache\Storage\Adapter\RedisOptions' => [
+                'server' => [
+                    'host' => 'localhost',
+                    'port' => 6379,
+                    'timeout' => 0,
+                ],
+            ],
         ],
         'shared' => [
             'Laminas\Form\Factory' => false,

--- a/test/TestAsset/ConfigPostProcessor/FullServiceManagerConfiguration.php.out
+++ b/test/TestAsset/ConfigPostProcessor/FullServiceManagerConfiguration.php.out
@@ -10,7 +10,7 @@ return [
             'Laminas\Cache\Storage\StorageInterface' => 'Laminas\Cache\Storage\Adapter\Redis',
             'Zend\Expressive\Router\RouterInterface' => 'Mezzio\Router\RouterInterface',
             'Zend\Form\Factory' => 'Laminas\Form\Factory',
-
+            'Zend\Cache\Storage\Adapter\Redis' => 'Laminas\Cache\Storage\Adapter\Redis',
         ],
         'delegators' => [
             'Laminas\Cache\Storage\Adapter\Redis' => [

--- a/test/TestAsset/ConfigPostProcessor/InvalidServiceManagerConfiguration.php
+++ b/test/TestAsset/ConfigPostProcessor/InvalidServiceManagerConfiguration.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    'service_manager' => [
+        'aliases' => [
+            'MyAlias' => 'MyOtherService',
+        ],
+        'factories' => [
+            'MyOtherService', 'MyOtherFactory',
+            'MyOtherService' => 'MyOtherFactory',
+        ],
+    ],
+];

--- a/test/TestAsset/ConfigPostProcessor/InvalidServiceManagerConfiguration.php
+++ b/test/TestAsset/ConfigPostProcessor/InvalidServiceManagerConfiguration.php
@@ -9,5 +9,9 @@ return [
             'MyOtherService', 'MyOtherFactory',
             'MyOtherService' => 'MyOtherFactory',
         ],
+        'invokables' => [
+            'Foo', 'Bar',
+            'Foo' => 'Bar',
+        ],
     ],
 ];

--- a/test/TestAsset/ConfigPostProcessor/InvalidServiceManagerConfiguration.php
+++ b/test/TestAsset/ConfigPostProcessor/InvalidServiceManagerConfiguration.php
@@ -13,5 +13,8 @@ return [
             'Foo', 'Bar',
             'Foo' => 'Bar',
         ],
+        'services' => [
+            'Invalid',
+        ],
     ],
 ];

--- a/test/TestAsset/ConfigPostProcessor/InvalidServiceManagerConfiguration.php.out
+++ b/test/TestAsset/ConfigPostProcessor/InvalidServiceManagerConfiguration.php.out
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    'service_manager' => [
+        'aliases' => [
+            'MyAlias' => 'MyOtherService',
+        ],
+        'factories' => [
+            'MyOtherService', 'MyOtherFactory',
+            'MyOtherService' => 'MyOtherFactory',
+        ],
+    ],
+];

--- a/test/TestAsset/ConfigPostProcessor/InvalidServiceManagerConfiguration.php.out
+++ b/test/TestAsset/ConfigPostProcessor/InvalidServiceManagerConfiguration.php.out
@@ -9,5 +9,9 @@ return [
             'MyOtherService', 'MyOtherFactory',
             'MyOtherService' => 'MyOtherFactory',
         ],
+        'invokables' => [
+            'Foo', 'Bar',
+            'Foo' => 'Bar',
+        ],
     ],
 ];

--- a/test/TestAsset/ConfigPostProcessor/InvalidServiceManagerConfiguration.php.out
+++ b/test/TestAsset/ConfigPostProcessor/InvalidServiceManagerConfiguration.php.out
@@ -13,5 +13,8 @@ return [
             'Foo', 'Bar',
             'Foo' => 'Bar',
         ],
+        'services' => [
+            'Invalid',
+        ],
     ],
 ];

--- a/test/TestAsset/ConfigPostProcessor/LazyServices.php
+++ b/test/TestAsset/ConfigPostProcessor/LazyServices.php
@@ -1,0 +1,24 @@
+<?php
+
+use Zend\ServiceManager\Factory\InvokableFactory;
+use Zend\ServiceManager\Proxy\LazyServiceFactory;
+
+return [
+    'dependencies' => [
+        'factories' => [
+            'Zend\Db\Adapter\Adapter' => 'Zend\ServiceManager\AbstractFactory\ReflectionBasedAbstractFactory',
+        ],
+        'lazy_services' => [
+            // Mapping services to their class names is required
+            // since the ServiceManager is not a declarative DIC.
+            'class_map' => [
+                'Zend\Db\Adapter\Adapter' => 'Zend\Db\Adapter\Adapter',
+            ],
+        ],
+        'delegators' => [
+            'Zend\Db\Adapter\Adapter' => [
+                LazyServiceFactory::class,
+            ],
+        ],
+    ],
+];

--- a/test/TestAsset/ConfigPostProcessor/LazyServices.php.out
+++ b/test/TestAsset/ConfigPostProcessor/LazyServices.php.out
@@ -1,0 +1,24 @@
+<?php
+
+use Laminas\ServiceManager\Factory\InvokableFactory;
+use Laminas\ServiceManager\Proxy\LazyServiceFactory;
+
+return [
+    'dependencies' => [
+        'factories' => [
+            'Laminas\Db\Adapter\Adapter' => 'Laminas\ServiceManager\AbstractFactory\ReflectionBasedAbstractFactory',
+        ],
+        'lazy_services' => [
+            // Mapping services to their class names is required
+            // since the ServiceManager is not a declarative DIC.
+            'class_map' => [
+                'Laminas\Db\Adapter\Adapter' => 'Laminas\Db\Adapter\Adapter',
+            ],
+        ],
+        'delegators' => [
+            'Laminas\Db\Adapter\Adapter' => [
+                LazyServiceFactory::class,
+            ],
+        ],
+    ],
+];

--- a/test/TestAsset/ConfigPostProcessor/LazyServices.php.out
+++ b/test/TestAsset/ConfigPostProcessor/LazyServices.php.out
@@ -20,5 +20,8 @@ return [
                 LazyServiceFactory::class,
             ],
         ],
+        'aliases' => [
+            'Zend\Db\Adapter\Adapter' => 'Laminas\Db\Adapter\Adapter'
+        ],
     ],
 ];


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

With laminas/laminas-zendframework-bridge#60 it came up, that we have missed the `delegators`.
After further investigation, I found out that we also dropped handling for some other keys of the `ServiceManager` configuration.

Thus, I've added the following keys to the `ConfigPostProcessor` aswell:
- handles `abstract_factories`
- handles `initializers`
- handles `lazy_services`
- handles `services`
- handles `shared`

---

After some discussions with @michalbundyra (as we both had the same issues while migrating real-world projects), we also found out that we do not handle invalid configurations.

First of all, we are just skipping that invalid configurations and keep them as they are.
In a next step, we create a new feature in `laminas/laminas-servicemanager` where one can add a `strict` flag to all `ServiceManager` configurations (including plugin managers of course), which will verify that the configuration is set correctly. In one of the next minor versions of `laminas/laminas-servicemanager`, the flag might be set to `false` per-default. In the next major, this will change to `true` per-default and throws exceptions on invalid configurations.
