### PR TITLE
Do not rewrite references to BjyAuthorize templates

### DIFF
--- a/config/replacements.php
+++ b/config/replacements.php
@@ -3,6 +3,7 @@
 return [
     // NEVER REWRITE
     'zendframework/zendframework' => 'zendframework/zendframework',
+    'zend-developer-tools/toolbar/bjy' => 'zend-developer-tools/toolbar/bjy',
     'zend-developer-tools/toolbar/doctrine' => 'zend-developer-tools/toolbar/doctrine',
 
     // NAMESPACES

--- a/test/ReplacementsTest.php
+++ b/test/ReplacementsTest.php
@@ -34,6 +34,10 @@ class ReplacementsTest extends TestCase
             'Northwoods\Container\Zend\Config',
             'Northwoods\Container\Zend\Config',
         ];
+        yield 'BjyAuthorize' => [
+            'zend-developer-tools/toolbar/bjy-authorize-role',
+            'zend-developer-tools/toolbar/bjy-authorize-role',
+        ];
         yield 'Expressive ZendRouter' => [
             'Zend\Expressive\Router\ZendRouter',
             'Mezzio\Router\LaminasRouter',


### PR DESCRIPTION
Adds a "never rewrite" rule to the replacements map to never rewrite references to `zend-developer-tools/toolbar/bjy`. This ensures that the BjyAuthorize plugins to the developer tools will continue to work correctly.

Fixes #65