### PR TITLE
Verify `COMPOSER_VENDOR_DIR` in conditional

### DIFF
--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -1,4 +1,8 @@
-# https://help.github.com/en/categories/automating-your-workflow-with-github-actions
+# Alternate workflow example.
+# This one is identical to the one in release-on-milestone.yml, with one change:
+# the Release step uses the ORGANIZATION_ADMIN_TOKEN instead, to allow it to
+# trigger a release workflow event. This is useful if you have other actions
+# that intercept that event.
 
 name: "Automatic Releases"
 
@@ -21,7 +25,7 @@ jobs:
         with:
           command-name: "laminas:automatic-releases:release"
         env:
-          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
+          "GITHUB_TOKEN": ${{ secrets.ORGANIZATION_ADMIN_TOKEN }}
           "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
           "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
@@ -50,6 +54,16 @@ jobs:
         uses: "laminas/automatic-releases@v1"
         with:
           command-name: "laminas:automatic-releases:bump-changelog"
+        env:
+          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
+          "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
+          "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
+          "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
+
+      - name: "Create new milestones"
+        uses: "laminas/automatic-releases@v1"
+        with:
+          command-name: "laminas:automatic-releases:create-milestones"
         env:
           "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
           "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#71](https://github.com/laminas/laminas-zendframework-bridge/pull/71) fixes detection of the vendor directory when the `COMPOSER_VENDOR_DIR` env variable is missing or empty. Previously, this could lead to scenarios where a non-existent path was used for finding the bridge autoloader.
 
 ## 1.1.0 - 2020-08-18
 

--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -66,7 +66,7 @@ class Autoloader
      */
     private static function getClassLoader()
     {
-        if (file_exists(getenv('COMPOSER_VENDOR_DIR') . '/autoload.php')) {
+        if (getenv('COMPOSER_VENDOR_DIR') && file_exists(getenv('COMPOSER_VENDOR_DIR') . '/autoload.php')) {
             return include getenv('COMPOSER_VENDOR_DIR') . '/autoload.php';
         }
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This corrects an issue where `COMPOSER_VENDOR_DIR` could be an empty value and this condition erroneously runs. Before running this condition we need to confirm `COMPOSER_VENDOR_DIR` is set and contains a value.

For further details on this issue see:

- craftcms/cms#6773
- laminas/laminas-feed#22