### PR TITLE
Allow the composer class loader to be absent, for `composer/composer:2.2.0` compatibility

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -12,9 +12,6 @@
       <code>$class</code>
       <code>$class</code>
     </MissingClosureParamType>
-    <MissingFile occurrences="1">
-      <code>include __DIR__ . '/../../../autoload.php'</code>
-    </MissingFile>
     <MissingReturnType occurrences="1">
       <code>load</code>
     </MissingReturnType>
@@ -35,13 +32,6 @@
       <code>$namespaces[$check]</code>
       <code>$namespaces[$check]</code>
     </MixedOperand>
-    <PossiblyFalseOperand occurrences="2">
-      <code>getenv('COMPOSER_VENDOR_DIR')</code>
-      <code>getenv('COMPOSER_VENDOR_DIR')</code>
-    </PossiblyFalseOperand>
-    <UnresolvableInclude occurrences="1">
-      <code>include getenv('COMPOSER_VENDOR_DIR') . '/autoload.php'</code>
-    </UnresolvableInclude>
   </file>
   <file src="src/ConfigPostProcessor.php">
     <InvalidArgument occurrences="1">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -31,18 +31,10 @@
     <MixedArrayOffset occurrences="1">
       <code>$loaded[$class]</code>
     </MixedArrayOffset>
-    <MixedInferredReturnType occurrences="1">
-      <code>ClassLoader</code>
-    </MixedInferredReturnType>
     <MixedOperand occurrences="2">
       <code>$namespaces[$check]</code>
       <code>$namespaces[$check]</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="3">
-      <code>include __DIR__ . '/../../../autoload.php'</code>
-      <code>include __DIR__ . '/../vendor/autoload.php'</code>
-      <code>include getenv('COMPOSER_VENDOR_DIR') . '/autoload.php'</code>
-    </MixedReturnStatement>
     <PossiblyFalseOperand occurrences="2">
       <code>getenv('COMPOSER_VENDOR_DIR')</code>
       <code>getenv('COMPOSER_VENDOR_DIR')</code>

--- a/test/AutoloaderTest.php
+++ b/test/AutoloaderTest.php
@@ -3,14 +3,20 @@
 namespace LaminasTest\ZendFrameworkBridge;
 
 use Laminas\LegacyTypeHint;
+use Laminas\ZendFrameworkBridge\Autoloader;
 use PHPUnit\Framework\TestCase;
 
 use function class_exists;
+use function clearstatcache;
+use function file_exists;
 use function get_class;
 use function interface_exists;
+use function rename;
 
 class AutoloaderTest extends TestCase
 {
+    private const PATH_TO_AUTOLOADER = __DIR__ . '/../vendor/autoload.php';
+
     /**
      * @return array[]
      */
@@ -138,5 +144,23 @@ class AutoloaderTest extends TestCase
     {
         self::assertTrue(class_exists($actual));
         self::assertTrue(class_exists($legacy));
+    }
+
+    public function testCanHandleNonExistentAutoloadFile(): void
+    {
+        self::assertTrue(file_exists(self::PATH_TO_AUTOLOADER));
+        $pathToAutoloaderBackup = sprintf('%s.bak', self::PATH_TO_AUTOLOADER);
+        rename(self::PATH_TO_AUTOLOADER, $pathToAutoloaderBackup);
+        clearstatcache();
+        self::assertFalse(file_exists(self::PATH_TO_AUTOLOADER));
+
+        try {
+            Autoloader::load();
+        } finally {
+            rename($pathToAutoloaderBackup, self::PATH_TO_AUTOLOADER);
+        }
+
+        clearstatcache();
+        self::assertTrue(file_exists(self::PATH_TO_AUTOLOADER));
     }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

With composer 2.2.0, some autoloaders are loaded even before the `vendor/autoload.php` file is dumped.
This leads to installation crashes in some circumstances due to the fact that this component throws a `RuntimeException` in case the autoloader could not be found.

Due to the fact, that this works properly after the autoloader got dumped, we can safely not register the prepend/append autoloader registration for this case.

Closes #89 