### PR TITLE
Allow configuration of additional replacements

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,52 @@ Run the following to install this library:
 $ composer require laminas/laminas-zendframework-bridge
 ```
 
+## Configuration
+
+- Since 1.6.0
+
+You may provide additional replacements for the configuration post processor.
+This is particularly useful if your application uses third-party components that include class names that the post processor otherwise rewrites, and which you want to never rewrite.
+
+Configuration is via the following structure:
+
+```php
+return [
+    'laminas-zendframework-bridge' => [
+        'replacements' => [
+            'to-replace' => 'replacement',
+            // ...
+        ],
+    ],
+];
+```
+
+As an example, if your configuration included the following dependency mapping:
+
+```php
+return [
+    'controller_plugins' => [
+        'factories' => [
+            'customZendFormBinder' => \CustomZendFormBinder\Controller\Plugin\Factory\BinderPluginFactory::class,
+        ],
+    ],
+];
+```
+
+And you wanted the two strings that contain the verbiage `ZendForm` to remain untouched, you could define the following replacements mapping:
+
+```php
+return [
+    'laminas-zendframework-bridge' => [
+        'replacements' => [
+            // Never rewrite!
+            'customZendFormBinder' => 'customZendFormBinder',
+            'CustomZendFormBinder' => 'CustomZendFormBinder',
+        ],
+    ],
+];
+```
+
 ## Support
 
 * [Issues](https://github.com/laminas/laminas-zendframework-bridge/issues/)

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.21.0@d8bec4c7aaee111a532daec32fb09de5687053d1">
+<files psalm-version="4.9.3@4c262932602b9bbab5020863d1eb22d49de0dbf4">
   <file src="config/replacements.php">
     <DuplicateArrayKey occurrences="3">
       <code>'ZendAcl' =&gt; 'LaminasAcl'</code>
@@ -8,7 +8,10 @@
     </DuplicateArrayKey>
   </file>
   <file src="src/Autoloader.php">
-    <MixedArgumentTypeCoercion occurrences="2"/>
+    <MixedArgumentTypeCoercion occurrences="2">
+      <code>RewriteRules::namespaceReverse()</code>
+      <code>RewriteRules::namespaceRewrite()</code>
+    </MixedArgumentTypeCoercion>
   </file>
   <file src="src/ConfigPostProcessor.php">
     <InvalidArgument occurrences="1">
@@ -59,7 +62,7 @@
     <MixedArrayTypeCoercion occurrences="1">
       <code>$aliases[$name]</code>
     </MixedArrayTypeCoercion>
-    <MixedAssignment occurrences="25">
+    <MixedAssignment occurrences="27">
       <code>$a[$key]</code>
       <code>$a[$key]</code>
       <code>$a[]</code>
@@ -75,8 +78,10 @@
       <code>$key</code>
       <code>$name</code>
       <code>$newKey</code>
+      <code>$newValue</code>
       <code>$notIn[]</code>
       <code>$result</code>
+      <code>$rewritten[$key]</code>
       <code>$rewritten[$key]</code>
       <code>$rewritten[$newKey]</code>
       <code>$rewritten[$newKey][]</code>


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

This patch adds the ability to configure additional replacement mappings via configuration:

```php
return [
    'laminas-zendframework-bridge' => [
        'replacements' => [
            // Never rewrite!
            'customZendFormBinder' => 'customZendFormBinder',
            'CustomZendFormBinder' => 'CustomZendFormBinder',
        ],
    ],
];
```

The `laminas-zendframework-bridge` configuration itself will never be rewritten.
Any replacements found in configuration passed to the processor, however, will be used to seed a `Replacements` instance, thus allowing additional rules.
In the example above, we're indicating that if those specific strings are found, they should NOT be rewritten.

Fixes #94
