### PR TITLE
Extract recursive method from ConfigPostProcessor::__invoke() to avoid performance hit

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.9.3@4c262932602b9bbab5020863d1eb22d49de0dbf4">
+<files psalm-version="4.21.0@d8bec4c7aaee111a532daec32fb09de5687053d1">
   <file src="config/replacements.php">
     <DuplicateArrayKey occurrences="3">
       <code>'ZendAcl' =&gt; 'LaminasAcl'</code>
@@ -41,9 +41,7 @@
       <code>$newKey</code>
       <code>$target</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
-      <code>[$key]</code>
-    </MixedArgumentTypeCoercion>
+    <MixedArgumentTypeCoercion occurrences="1"/>
     <MixedArrayAssignment occurrences="4">
       <code>$config[$key]</code>
       <code>$config['aliases'][$alias]</code>
@@ -62,7 +60,7 @@
     <MixedArrayTypeCoercion occurrences="1">
       <code>$aliases[$name]</code>
     </MixedArrayTypeCoercion>
-    <MixedAssignment occurrences="27">
+    <MixedAssignment occurrences="26">
       <code>$a[$key]</code>
       <code>$a[$key]</code>
       <code>$a[]</code>
@@ -78,7 +76,6 @@
       <code>$key</code>
       <code>$name</code>
       <code>$newKey</code>
-      <code>$newValue</code>
       <code>$notIn[]</code>
       <code>$result</code>
       <code>$rewritten[$key]</code>


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

`Replacements` initialization depends on additional configuration from `$config`, for
that reason it is delayed until config post processor is invoked.
However, `__invoke()` method is used recursively leading to unneccessary
reinitialization of `Replacements` and a significant performance hit.

Functionality is extracted into `processConfig()` to be used internally
for recursive calls.
