### PR TITLE
Add PHP 8.3 support. Mark package abandoned.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "forum": "https://discourse.laminas.dev/"
     },
     "require": {
-        "php": "~8.1.0 || ~8.2.0"
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.4",

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "rss": "https://github.com/laminas/laminas-zendframework-bridge/releases.atom",
         "forum": "https://discourse.laminas.dev/"
     },
+    "abandoned": true,
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6a25a3b8554ce385f04431c6a2d5debe",
+    "content-hash": "7748ecdfd98016b0223c9c32975d1c2b",
     "packages": [],
     "packages-dev": [
         {
@@ -3765,7 +3765,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.1.0 || ~8.2.0"
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
     },
     "platform-dev": [],
     "platform-overrides": {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

This package was introduced to simplify migration from Zend Framework packages to Laminas. In a month it will be 4 years since Zend Framework migrated to Laminas. None of Zend Framework packages support php 8 and none of supported Laminas packages support php <8.

If users still depend on this package they are strongly urged to complete migration and remove this dependency.

